### PR TITLE
Copy clang proposals from hlsl-specs

### DIFF
--- a/proposals/0001-availability-diagnostics.md
+++ b/proposals/0001-availability-diagnostics.md
@@ -1,0 +1,319 @@
+<!-- {% raw %} -->
+
+# Strict Availability Diagnostics
+
+* Proposal: [0001](0001-availability-diagnostics.md)
+* Author(s): [Chris Bieneman](https://github.com/llvm-beanz), [Helena Kotas](https://github.com/hekota)
+* Sponsor: [Chris Bieneman](https://github.com/llvm-beanz)
+* Status: **Accepted**
+* Planned Version: 20YY (Clang-only)
+
+## Introduction
+
+Strict availability diagnostics introduces two new modes for diagnosing the use
+of unavailable shader APIs. Unavailable shader APIs are APIs that are exposed in
+HLSL code but are not available in the target shader stage or shader model
+version.
+
+## Motivation
+
+Today the enforcement of API availability is the responsibility of bytecode
+validators, runtimes and drivers operating on optimized shader code. Depending
+contextually on where this enforcement occurs this can result in errors being
+produced either late in compilation when mapping back to source locations is
+difficult or at runtime when the runtime or driver rejects the compiled shader.
+
+Strict availability diagnostics provides more actionable diagnostics for users
+by both having detailed error messages and accurate message locations. It also
+provides diagnostics early and allows implementations to generate meaningful
+diagnostics even without generation of debug information.
+
+> Note: The DXIL validator requires line table information to generate error
+> locations which can be inaccurate. Disabling line table information can have a
+> significant compile-time benefit.
+
+## Proposed solution
+
+### Availability Annotations
+
+In Clang, most shader APIs have header declarations that live in the default
+included `hlsl_intrinsics.h`. All shader API declarations have Clang
+availability attributes denoting version information for when the APIs are
+introduced, deprecated, and removed. This version annotation can be per-stage or
+for all stages. The availability annotations will need to exist on declarations
+regardless of this proposal, as they provide information to AST-based tooling
+such as IDE workflows.
+
+As an example of the annotations in action take the following declaration from
+`hlsl_intrinsics.h`:
+
+```c++
+__attribute__((availability(shadermodel, introduced = 6.0)))
+__attribute__((availability(vulkan, introduced = 1.0)))
+__attribute__((clang_builtin_alias(__builtin_hlsl_wave_active_count_bits)))
+uint WaveActiveCountBits(bool Bit);
+```
+
+> Note: the actual header uses macros to condense the attribute descriptions.
+> The example expands the macros for explicitness.
+
+The example above declares the `WaveActiveCountBits` function to require shader
+model 6.0+. This AST annotation allows clangd to communicate to users the
+availability information to language server protocol clients. This can drive
+more informed auto-complete, refactoring, and in-editor diagnostics.
+
+The Clang availability attribute works well when a function's availability
+depends only on the shader model version. However, the availability of some HLSL
+functions depends not only on the shader model version but also on the target
+shader stage. For example the derivative functions `ddx` and `ddy` were
+introduced in Shader Model 2.0 for use only in pixel shaders. In Shader Model
+6.6 their support was extended to compute, mesh and amplification shaders, and
+they are not available in any other shader stage.
+
+In order to encode this information we propose adding a new `environment`
+parameter to the Clang availability attribute. The allowed values would be
+identical to the environment component of the `llvm::Triple`. If the
+`environment` parameters is present, the declared availability attribute would
+apply only for targets with the same environment.
+
+Using the new `environment` parameter, the per-stage availability annotation for
+the derivative function `ddx` would look like this:
+
+```
+__attribute__((availability(shadermodel, introduced = 2.0, environment = pixel)))
+__attribute__((availability(shadermodel, introduced = 6.6, environment = compute)))
+__attribute__((availability(shadermodel, introduced = 6.6, environment = mesh)))
+__attribute__((availability(shadermodel, introduced = 6.6, environment = amplification)))
+__attribute__((availability(vulkan, introduced = 1.0)))
+__attribute__((clang_builtin_alias(__builtin_hlsl_ddx)))
+float ddx(float val);
+```
+
+If the `environment` parameter is not present, it means the function is available
+for all shader stages starting with the specified shader model version. If the
+parameter is present, then for non-library shaders it will be checked against the
+environment component of the target triple. For library shaders the
+`environment` parameter will be checked against the `[shader("...")]` attribute
+on the shader entry function.
+
+### Diagnostic Modes
+
+This proposal introduces three new modes for diagnosing API availability:
+default, relaxed, and strict.
+
+### Default Diagnostic Mode
+
+The default diagnostic mode performs an AST traversal after the translation unit
+has been fully parsed, and requires construction of a call graph. In the relaxed
+mode, an AST visitor will traverse to all `CallExpr` nodes that are reachable
+from exported functions (either library exports or entry functions). If the
+callee of a `CallExpr` has availability annotations that signify that the API is
+unavailable for the target shader model and stage the compiler emits an _error_.
+
+Clang encodes the target shader model version in the target triple, and the
+shader stage in the `HLSLShaderAttr` which is implicitly or explicitly applied
+to the entry function.
+
+The default mode does not issue diagnostics for `CallExpr` nodes that are inside
+functions which are not reachable from exported functions.
+
+### Relaxed Diagnostic Mode
+
+The implementation of the relaxed diagnostic mode matches the default mode,
+except that when a `CallExpr` references an unavailable API, the compiler emits
+a _warning_.
+
+The relaxed mode does not issue diagnostics for `CallExpr` nodes that are inside
+functions which are not reachable from exported functions. A user enables
+relaxed mode by passing `-Wno-error=hlsl-availability`.
+
+### Strict Diagnostic Mode
+
+The strict diagnostic mode strives to aggressively issue diagnostics. For
+non-library shaders, during parsing any callee of a `CallExpr` that has
+availability annotation that marks it as unavailable for the target shader model
+and stage will produce an _error_.
+
+For library shaders, during parsing any callee of a `CallExpr` that has
+availability annotation that marks it as unavailable for the target shader model
+version will produce an _error_. After parsing the translation unit, an AST
+visitor will traverse to all `CallExpr` nodes that are reachable from annotated
+shader entry functions. If the callee of a `CallExpr` has availability
+annotations that signify that the API is unavailable for the target shader stage
+the compiler emits an _error_.
+
+Unlike in the _default_ or _relaxed_ mode, the compiler will emit diagnostics
+for mismatched shader model version without the use of a call graph and
+regardless of reachability.
+
+A user enables strict mode by passing `-fhlsl-strict-diagnostics`.
+
+### Comparison Against Existing Behavior
+
+Today DXC allows the use of APIs in shaders regardless of the specified target
+profile. The responsibility for enforcing API availability falls to the bytecode
+validator. This results in compilation passing but the validator failing. For
+example take the following code:
+
+> [Godbolt Link](https://godbolt.org/z/v1sjEEETW)
+```c++
+Texture2D texture : register(t0);
+SamplerState samplerState : register(s0);
+
+FeedbackTexture2D<SAMPLER_FEEDBACK_MIN_MIP> map : register(u0);
+
+[numthreads(4, 4, 1)]
+void main(uint3 threadId : SV_DispatchThreadId) {
+  float2 uv = threadId.xy;
+  uv /= 256;
+
+  map.WriteSamplerFeedbackLevel(texture, samplerState, uv, threadId.x % 8);
+}
+```
+
+Compiled with the `-T cs_6_4` flag this produces the validation error:
+```
+<>:11:3: error: Opcode WriteSamplerFeedbackLevel not valid in shader model cs_6_4.
+note: at 'call void @dx.op.writeSamplerFeedbackLevel(i32 176, %dx.types.Handle %1, %dx.types.Handle %2, %dx.types.Handle %3, float %8, float %9, float undef, float undef, float %11)' in block '#0' of function 'main'.
+Validation failed.
+```
+
+This error displays the LLVM IR text for the error site, and attempts to
+attribute a line location in the HLSL source, it can be error prone. In a
+trivial example like the one above finding the error may be straightforward, but
+it does involve recognizing textual LLVM IR and the HLSL source that generated
+it.
+
+With this proposal under the _relaxed_ mode, clang will emit the following
+warning:
+
+```
+<>:11:6: warning: 'WriteSamplerFeedbackLevel' is available beginning with Shader Model 6.6
+   11 |   map.WriteSamplerFeedbackLevel(texture, samplerState, uv, threadId.x % 8);
+      |       ^~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+With this proposal under the _default_ or _strict_ mode, clang will emit the
+following error:
+
+```
+<>:11:6: error: 'WriteSamplerFeedbackLevel' is available beginning with Shader Model 6.6
+   11 |   map.WriteSamplerFeedbackLevel(texture, samplerState, uv, threadId.x % 8);
+      |       ^~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+To illustrate the difference between _default_ and _strict_ take the following
+example:
+
+```c++
+Texture2D texture : register(t0);
+SamplerState samplerState : register(s0);
+
+FeedbackTexture2D<SAMPLER_FEEDBACK_MIN_MIP> map : register(u0);
+
+void fn(uint3 threadId) {
+  float2 uv = threadId.xy;
+  uv /= 256;
+  map.WriteSamplerFeedbackLevel(texture, samplerState, uv, threadId.x % 8);
+}
+
+[numthreads(4, 4, 1)]
+void main(uint3 threadId : SV_DispatchThreadId) { }
+```
+
+In this example the call of the unavailable API is in an unused function. In
+both the _relaxed_ and _default_ diagnostic modes, clang will emit no
+diagnostics. In the _strict_ mode, clang emits the following diagnostic:
+
+```
+<>:9:6: error: 'WriteSamplerFeedbackLevel' is available beginning with Shader Model 6.6
+   9 |   map.WriteSamplerFeedbackLevel(texture, samplerState, uv, threadId.x % 8);
+     |       ^~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+In this case the DXIL validator will emit no diagnostic since the call to the
+unavailable API is not present in the final output.
+
+To illustrate the behavior for library shaders consider the following example:
+
+> [Godbolt Link](https://godbolt.org/z/rKMGz566M)
+```c++
+float d(float f) {
+  return ddx(f);
+}
+
+float dead(float f) {
+  return WaveMultiPrefixSum(f, 1.xxxx);
+}
+
+float also_dead(float f) {
+  return ddy(f)
+}
+
+[shader("vertex")]
+float main() : FOO {
+  float f = 3;
+  return d(f);
+}
+```
+
+When compiled with the `lib_6_3` profile under the _default_ mode, clang will
+emit the following error:
+
+```
+<>:1:9: error: 'ddx' is not available in vertex shaders
+   9 |   return ddx(f);
+     |          ^~~
+```
+
+When compiled with the `lib_6_3` profile under the _strict_ mode, clang will
+emit the following errors:
+
+```
+<>:1:9: error: 'ddx' is not available in vertex shaders
+   9 |   return ddx(f);
+     |          ^~~
+<>:6:9: error: 'WaveMultiPrefixSum' is available beginning with Shader Model 6.5
+   9 |   return WaveMultiPrefixSum(f, 1.xxxx);
+     |          ^~~~~~~~~~~~~~~~~~
+```
+
+Neither case results in a diagnostic emission for the `ddy` call in `also_dead`
+because the function is not called and `ddy` is valid in the target shader model
+version.
+
+Because bytecode validation occurs late (after optimization), some more complex
+cases can occur. For example, users have reported situations that produce
+validation errors when building un-optimized shaders for debugging proposes that
+do not appear with optimized shaders.
+
+One presentation of such a case is if a call to an unavailable API occurs under
+control flow. If the compiler optimizes away the control flow it may remove the
+API call. In these cases shaders that compile and verify successfully with DXC
+may produce warnings or errors with Clang.
+
+### Diagnostic text
+
+The diagnostic message should reflect whether the function is not available for
+the shader model version or just for the specific shader stage. In other words,
+it should be relevant to the entry point type. 
+
+If function `a` is available in a shader model higher than the target shader
+model regardless of target shader stage the diagnostic message should be:
+```
+'a' is only available on Shader Model x.y or newer
+```
+
+If function `a` is not available in shader stage `S` regardless of shader model
+version the diagnostic message should be:
+```
+'a' is not available in S shader environment on Shader Model x.y
+```
+
+If function `a` is available in shader stage `S` in shader model higher than the
+target shader model the diagnostic message should be:
+```
+'a' is only available in S shader environment on Shader Model x.y or newer
+```
+
+<!-- {% endraw %} -->

--- a/proposals/0002-root-signature-in-clang.md
+++ b/proposals/0002-root-signature-in-clang.md
@@ -2,7 +2,7 @@
 
 # Implementation of Root Signatures in Clang
 
-* Proposal: [0002](INF-0002-root-signture-in-clang.md)
+* Proposal: [0002](0002-root-signture-in-clang.md)
 * Author(s): [Xiang Li](https//github.com/python3kgae), [Damyan
   Pepper](https://github.com/damyanp)
 * Sponsor: Damyan Pepper

--- a/proposals/0003-packoffset.md
+++ b/proposals/0003-packoffset.md
@@ -1,0 +1,173 @@
+<!-- {% raw %} -->
+
+# packoffset attribute
+
+* Proposal: [0003](0003-packoffset.md)
+* Author(s): [Xiang Li](https://github.com/python3kgae)
+* Sponsor: 
+* Status: **Under Consideration**
+* Planned Version: 
+
+## Introduction
+
+packoffset attribute is used to change the layout of a cbuffer.
+
+```
+packoffset( c[Subcomponent][.component] )
+```
+
+It will overwrite the layout of a cbuffer with the packoffset attributes on
+the constants.
+
+Here are several examples of manually packing shader constants.
+
+```
+cbuffer MyBuffer
+{
+    float4 Element1 : packoffset(c0);
+    float1 Element2 : packoffset(c12);
+    float1 Element3 : packoffset(c1.y);
+}
+```
+without the packoffset, Element2 will be in c1.x.
+
+
+### Limitations
+
+There're some limitations when apply packoffset on a constant.
+
+1. packoffset is only allowed in a constant buffer.
+```
+float c : packoffset(c0); // invalid for apply packoffset on a global constant.
+```
+
+2. cannot mix packoffset elements with nonpackoffset elements in a cbuffer.
+```
+cbuffer A {
+  float a : packoffset(c0);
+  float b;  // invalid for mix packoffset elements and nonpackoffset elements.
+}
+```
+3. Pack subcomponents of vectors and scalars whose size is large enough to prevent crossing register boundaries.
+```
+cbuffer A {
+  float2 a : packoffset(c0.w); // invalid for a.x in c0.w and a.y in c1.x 
+                               // which crossed register boundary.
+}
+```
+4. struct, matrix, array cannot have component.
+```
+struct S {
+  float a;
+};
+
+cbuffer A{
+  S s : packoffset(c2.y); // invalid for offset to component y
+  int a[2] : packoffset(c3.z); // invalid for offset to component z
+  float2x2 m : packoffset(c6.z); // invalid for offset to component z
+  S s2 : packoffset(c12); // valid
+  int a2[2] : packoffset(c13); // valid
+  float2x2 m2 : packoffset(c16); // valid
+}
+```
+
+## Motivation
+
+To support all HLSL features available in compute profile.
+
+## Proposed solution
+
+### AST
+
+A new attribute HLSLPackOffsetAttr will be created with:
+```
+def HLSLPackOffset: HLSLAnnotationAttr {
+  let Spellings = [HLSLAnnotation<"packoffset">];
+  let LangOpts = [HLSL]
+  let Args = [IntArgument<"RegNum">, IntArgument<"Component", /*optional*/ 1>]
+}
+```
+
+The AST for MyBuffer example will be
+```
+HLSLBufferDecl cbuffer MyBuffer
+  VarDecl Element1 float4
+    HLSLPackOffsetAttr   0 0
+  VarDecl Element2 float
+    HLSLPackOffsetAttr  12 0
+  VarDecl Element3 float
+    HLSLPackOffsetAttr   1 1
+  
+```
+
+### llvm IR
+
+#### Layout struct for cbuffer
+In HLSL, constants inside a cbuffer have the cbuffer as their declaration 
+context. 
+However, the variable scope of these constants is similar to a regular 
+global variable. For instance, in the MyBuffer example, the constants are 
+accessed as Element1 instead of MyBuffer::Element1. 
+These constants are treated as global variables in clang AST.
+At the end of Clang’s code generation, cbuffer will be translated into a 
+global variable layout the cbuffer as a struct and replace the use of all 
+the constants with fields for the global variable.
+If translate into C,
+ ```
+ cbuffer A {
+   float a;
+   float b;
+ }
+ float foo() { return a + b; }
+```
+ will be translated into
+```
+ struct A {
+   float a;
+   float b;
+ } cbuffer_A;
+ float foo() { return cbuffer_A.a + cbuffer_A.b; }
+```
+struct A will created as the layout struct.
+The use of a and b will be replaced with cbuffer_A.a and cbuffer_A.b.
+
+#### packoffset on layout struct
+To apply the packoffset to a cbuffer, the layout of the struct constructed for 
+the cbuffer requires reordering of its fields, and padding should be introduced
+if any gaps exist between the fields.
+```
+cbuffer CB {
+  float a : packoffset(c2);
+  float b : packoffset(c4);
+  float2 c : packoffset(c2.z);
+}
+```
+will get layout struct like
+```
+struct CBLayout {
+  float4 padding0[2]; // c0/c1
+  float a;         // c2.x
+  float padding1;  // c2.y
+  float2 c;        // c2.zw
+  float4 padding;  // c3
+  float b;         // c4.x
+}
+```
+
+cbuffer llvm IR is not finalized yet.
+llvm IR example will be added once cbuffer llvm IR is ready.
+
+### metadata for reflection
+
+Reflection reqire cbuffer offer the name, type, offset for each constant inside it.
+This will be send to DirectX backend with metadata.
+The reflection data is tracked with https://github.com/llvm/llvm-project/issues/89292.
+Once that issue is resolved, packoffset only need to update the offset part of the 
+metadata for cbuffer.
+
+## Unresolved issue
+
+How to support 16bit types.
+The offset like c0.y is 32bit.
+
+<!-- {% endraw %} -->

--- a/proposals/0004-register-types-and-diagnostics.md
+++ b/proposals/0004-register-types-and-diagnostics.md
@@ -1,0 +1,155 @@
+<!-- {% raw %} -->
+* Proposal: [0004](0004-register-types-and-diagnostics.md)
+* Author(s): [Joshua Batista](https://github.com/bob80905)
+* Sponsor: TBD
+* Status: **Under Consideration**
+* Impacted Project(s): (LLVM)
+* PRs: [#87578](https://github.com/llvm/llvm-project/pull/87578)
+* Issues: [#57886](https://github.com/llvm/llvm-project/issues/57886)
+
+## Introduction
+Register binding syntax in HLSL is used to assign binding locations for
+resources and offsets for constants in constant buffers.
+For example:
+```hlsl
+RWBuffer<float> rwbuf : register(u0);
+```
+In this syntax, `: register(u0)` indicates a resource binding location for a
+UAV resource. Further, the resource type (or variable type) is `RWBuffer`, with a
+resource element type of `float` being declared as the variable `rwbuf`.
+The register type is `u` and the register number is `0`.
+There are a variety of rules for register bindings that require compiler
+diagnostics.  This document proposes a clear set of rules and diagnostics for
+this register binding annotation and outlines an approach to implementing these
+rules in the compiler.
+
+## Motivation
+
+Diagnostic behavior for register binding annotations in DXC and FXC can be
+problematic in a variety of ways.  Attempting to copy the behavior of these
+compilers going forward is undesirable. As such, there is a need to more
+clearly specify the expected compiler behavior to make it more friendly and
+predictable for users.
+Problematic cases include unsupported DirectX 9 bindings that are allowed,
+ignored, or even suggested as fixes for invalid bindings by the compiler.
+For example, in the case of:
+
+`float b : register(u4);`
+
+an error will be emitted recommending the use of the 'b, c, or i' register
+type. However the 'i' register type is no longer in support, and the 'b'
+register type is only reserved for resource types that are constant buffers.
+It is worth noting that there is an overloading of the register(...) keyword
+using the 'c' register type to indicate an offset into a constant buffer for
+numeric types only, as opposed to specifying a resource binding.
+Additionally, it is possible the user is unaware that this variable won't
+actually be used as a resource, but the compiler doesn't communicate that
+to the user. We should make it clear in this document which variables are
+compatible with which register types.
+
+## Proposed Solution
+
+The resource binding attribute will be attached to any declaration object (Decl)
+that has the `: register(...)` annotation. In Sema, this attribute has a function to
+validate its correctness, called `handleResourceBindingAttr`, within
+`clang\lib\Sema\SemaHLSL.cpp`. The diagnostic infrastructure will be implemented
+within this validation function to analyze the declaration that the annotation
+is applied to, and validate that the register type used within the annotation is semantically
+compatible with the Decl. All of this analysis and validation will be executed
+inside a new function, `DiagnoseHLSLRegisterAttribute`. This function will be
+responsible for validating the semantic meaning behind the application of the
+attribute, while the rest of `handleResourceBindingAttr` is responsible for
+validating the syntax of the attribute.
+
+### Recognized Register Types
+
+There are two types of register bindings, resource bindings and constant register bindings.
+
+Resource register bindings bind a resource like a texture or sampler to a location that is
+mapped using the root signature in DX12.
+
+Constant register bindings were originally used to bind values to one of three specialized
+constant register banks in DX9.  In DX10 and above, the `c` register binding for the `float`
+register bank maps to an offset into the `$Globals` constant buffer and the other two bindings
+are unused.
+
+This table lists the recognized register types, the associated resource class if applicable,
+along with some brief notes.
+
+| Register | Resource | Notes                                                                                 |
+| -------- | -------- | ------------------------------------------------------------------------------------- |
+| `t`      | SRV      | read-only texture, buffer, or `tbuffer`/`TextureBuffer`                               |
+| `u`      | UAV      | read/write texture or buffer                                                          |
+| `s`      | Sampler  | `SamplerState` or `SamplerComparisonState`                                            |
+| `b`      | CBV      | `cbuffer`/`ConstantBuffer` resource; also unsupported legacy `bool` constant register |
+| `c`      | N/A      | legacy `float` constant register - offset into `$Globals`                             |
+| `i`      | N/A      | unsupported legacy `int` constant register
+
+### Register binding contexts
+
+Register bindings may be applied to declarations in several contexts.  This table lists contexts and potentially applicable bindings.
+
+| Decl                                                       | Registers          | Context                                    | Notes                                                                                                                                                                                     |
+| ---------------------------------------------------------- | ------------------ | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cbuffer` or `tbuffer` decl                                | `b`, `t`           | any global                                 | `b` for `cbuffer`, `t` for `tbuffer`                                                                                                                                                      |
+| (array of) resource                                        | `t`, `u`, `b`, `s` | any global                                 | depends on resource class                                                                                                                                                                 |
+| struct/class instance (UDT)                                | `c`, `t`, `s`      | global outside `cbuffer` or `tbuffer` decl | `c` specifies starting location for data members of struct in `$Globals` constant buffer; `t` and `s` specify starting registers for binding any contained SRV and Samplers, respectively |
+| struct/class instance (UDT)                                | `t`, `s`           | global inside `cbuffer` or `tbuffer` decl  | `c` register binding may not be used inside `cbuffer` or `tbuffer` context; must use `packoffset` instead                                                                                 |
+| (array of) scalar, vector, or matrix numeric or bool types | `c`                | global outside `cbuffer` or `tbuffer` decl | `c` specifies starting location for numeric/bool values in `$Globals` constant buffer                                                                                                     |
+
+
+`DiagnoseHLSLRegisterAttribute` will validate that the variable type is bound using the
+expected register type. `DiagnoseHLSLRegisterAttribute` will be
+responsible for determining if register types are used correctly in certain
+legacy contexts, or whether such uses are invalid. Specifically, the `c` register
+type may only be used in global contexts. In those contexts, a resource isn't being bound,
+rather a variable is being placed in the $Globals buffer with a specified offset.
+Using `c` within a cbuffer or tbuffer is legacy behavior that should no longer be
+supported, so `DiagnoseHLSLRegisterAttribute` will emit a warning in this case
+that will be treated as an error by default. When this attribute appears in a non-global
+context, `packoffset` will be recommended as an alternative.
+The `i` register type is also a legacy DirectX 9 register type that
+will no longer be supported, and so a warning will be emitted that is treated
+as an error by default when this register type is used.
+The `b` register type, when used on a variable that isn't a resource, and doesn't
+have a `CBuffer` resource class, is also legacy behavior that will no longer be
+supported. In such cases, a warning will be emitted that is treated as an error by
+default, and a suggestion will be made that the register type is only used for resources with
+the `CBuffer` resource class.
+These warnings are all part of a distinct warning group, `LegacyConstantRegisterBinding`
+which can be silenced if a developer would prefer to enable compilation of legacy shaders.
+
+Another common case for this annotation to appear in HLSL is for user-defined-types (UDTs).
+UDTs may have multiple register annotations applied onto the variable declaration.
+`DiagnoseHLSLRegisterAttribute` will be responsible for ensuring that none of the
+register annotations conflict (none may have the same register type). `DiagnoseHLSLRegisterAttribute`
+will also ensure that any register annotations with a specific register type applied to
+the UDT will have a corresponding member in the UDT that can be bound by that register
+type (or can be placed into the $Globals constant buffer in the case of `c`). If there
+is no corresponding member, a warning will be emitted that is treated as an error by default,
+because this behavior was permissible in legacy versions of the compiler. These warnings
+are also part of the same warning group, `LegacyConstantRegisterBinding`.
+
+`DiagnoseHLSLRegisterAttribute` will also be responsible for emitting a diagnostic
+if any other invalid register type is detected. If `DiagnoseHLSLRegisterAttribute`
+finds any critical errors, the attribute, `HLSLResourceBindingAttr`, won't be added
+to the Decl, and compilation will fail. However, `DiagnoseHLSLRegisterAttribute` may
+emit some warnings and allow the attribute to be attached. In summary,
+`DiagnoseHLSLRegisterAttribute` will be responsible for analyzing the context of the
+decl to which the register annotation is being applied, and using the data in the
+annotation to determine what diagnostics, if any, to emit.
+`DiagnoseHLSLRegisterAttribute` will be fully responsible for halting compilation
+if there is any semantic fault in the application of the register annotation.
+
+
+## Detailed design
+
+TODO: Fill out and agree on detailed design
+
+## Acknowledgments (Optional)
+* Tex Riddell
+* Chris Bieneman
+* Justin Bogner
+* Damyan Pepper
+* Farzon Lotfi
+<!-- {% endraw %} -->

--- a/proposals/NNNN-root-signature-in-clang.md
+++ b/proposals/NNNN-root-signature-in-clang.md
@@ -1,0 +1,734 @@
+<!-- {% raw %} -->
+
+# Implementation of Root Signatures in Clang
+
+* Proposal: [0002](INF-0002-root-signture-in-clang.md)
+* Author(s): [Xiang Li](https//github.com/python3kgae), [Damyan
+  Pepper](https://github.com/damyanp)
+* Sponsor: Damyan Pepper
+* Status: **Under Consideration**
+* Impacted Project(s): Clang
+
+<!--
+*During the review process, add the following fields as needed:*
+
+* PRs: [#NNNN](https://github.com/microsoft/DirectXShaderCompiler/pull/NNNN)
+* Issues:
+  [#NNNN](https://github.com/microsoft/DirectXShaderCompiler/issues/NNNN)
+  -->
+
+## Introduction
+
+[Root
+Signatures](https://learn.microsoft.com/en-us/windows/win32/direct3d12/root-signatures-overview)
+can be [specified in
+HLSL](https://learn.microsoft.com/en-us/windows/win32/direct3d12/specifying-root-signatures-in-hlsl)
+and included in the generated DXContainer in a binary serialized format.
+Support for this functionality needs to be added to Clang.
+
+This change proposes adding:
+
+* New AST nodes to represent the root signature
+* A metadata representation of the root signature so it can be stored in LLVM IR
+* Validation and diagnostic generation for root signatures during semantic
+  analysis
+* Conversion of the metadata representation to the binary serialized format.
+
+## Motivation
+
+### What are Root Signatures?
+In DirectX HLSL, resources can be associated with registers.  For example:
+
+``` c++
+StructuredBuffer<float4> b1 : register(t0);
+StructuredBuffer<float4> b2 : register(t1);
+StructuredBuffer<float4> bn[] : register(t2);
+```
+
+In Direct3D 12, resources can be assigned to these registers. Root Signatures
+describe how these resources are set using the Direct3D API. A Root Signature
+describes a list of root parameters and how they map onto registers. These Root
+Signatures are all compatible with the HLSL shown above:
+
+Three parameters - two root descriptors and a descriptor table:
+
+```c++
+"SRV(t0),"
+"SRV(t1),"
+"DescriptorTable(SRV(t1, numDescriptors = unbounded))"
+```
+
+This would be set with C++ code that looks like this:
+
+```c++
+cl->SetGraphicsRootShaderResourceView(0, buffer1);
+cl->SetGraphicsRootShaderResourceView(1, buffer2);
+cl->SetGraphicsRootDescriptorTable(2, baseDescriptor);
+```
+
+A single parameter that's a descriptor table:
+```c++
+"DescriptorTable(SRV(t0, numDescriptors = unbounded))"
+```
+
+This would be set with C++ code that looks like this:
+
+```c++
+cl->SetGraphicsRootDescriptorTable(0, baseDescriptor);
+```
+
+The application creates a root signature by passing a serialized root signature
+blob to the
+[`CreateRootSignature`](https://learn.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-id3d12device-createrootsignature)
+method. This root signature must then be used when creating the Pipeline State
+Object and also set on the command list before setting any of the root
+parameters.
+
+### Specifying Root Signatures
+
+A serialized root signature blob can be built in an application by using the
+[`D3D12SerializeRootSignature`](https://learn.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-d3d12serializerootsignature)
+function. However, it is also helpful to be able to provide the shader compiler
+with a root signature so that it can perform validation against it and the
+shader being compiled. Also, the syntax for specifying a root signature in HLSL
+can be more convenient than setting up the various structures required to do so
+in C++. A compiled shader that contains a root signature can be passed to
+`CreateRootSignature`.
+
+In HLSL, Root Signatures are specified using a domain specific language as
+documented
+[here](https://learn.microsoft.com/en-us/windows/win32/direct3d12/specifying-root-signatures-in-hlsl).
+
+> TODO: link to Xiang's documentation that includes the grammar
+
+An example root signature string (see the documentation for some more extensive
+samples):
+
+```
+"RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), CBV(b0)"
+```
+
+A root signature can be associated with an entry point using the `RootSignature`
+attribute.  eg:
+
+```c++
+[RootSignature("RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), CBV(b0)")]
+float4 main(float4 coord : COORD) : SV_TARGET {
+    // ...
+}
+```
+
+The compiler can then verify that any resources used from this entry point are
+compatible with this root signature.
+
+In addition, when using [HLSL State
+Objects](https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-state-object)
+root signatures can also be specified using `GlobalRootSignature` and
+`LocalRootSignature`, where the same string format is used with the state object. eg:
+
+```c++
+GlobalRootSignature my_global_root_signature = { "CBV(b0), SRV(t0)" };
+LocalRootSignature my_local_root_signature = { "SRV(t1)" };
+```
+
+These root signatures (along with other subobjects) can be associated with
+exports from a shader libary like so:
+
+```c++
+SubobjectToExportsAssociation my_association = {
+    "my_global_root_signature",
+    "MyMissShader"
+};
+```
+
+> Note: HLSL State Objects are out of scope for this proposal, and so support
+> for LocalRootSignature and GlobalRootSignature is not covered in this
+> document.
+
+#### Note on the root signature domain specific language
+
+We have received feedback that the DSL for root signatures is not something that
+every language that targets DirectX would want to adopt. For this reason we need
+to ensure that our solution doesn't unnecessarily tie the non-HLSL parts to it.
+
+### Root Signature Grammar
+
+```
+    RootSignature : (RootElement(,RootElement)?)?
+
+    RootElement : RootFlags | RootConstants | RootCBV | RootSRV | RootUAV |
+                  DescriptorTable | StaticSampler
+
+    RootFlags : 'RootFlags' '(' (RootFlag(|RootFlag)?)? ')'
+
+    RootFlag : 0 |
+               'ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT' |
+               'DENY_VERTEX_SHADER_ROOT_ACCESS' |
+               'DENY_HULL_SHADER_ROOT_ACCESS' |
+               'DENY_DOMAIN_SHADER_ROOT_ACCESS' |
+               'DENY_GEOMETRY_SHADER_ROOT_ACCESS' |
+               'DENY_PIXEL_SHADER_ROOT_ACCESS' |
+               'DENY_AMPLIFICATION_SHADER_ROOT_ACCESS' |
+               'DENY_MESH_SHADER_ROOT_ACCESS' |
+               'ALLOW_STREAM_OUTPUT' |
+               'LOCAL_ROOT_SIGNATURE' |
+               'CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED' |
+               'SAMPLER_HEAP_DIRECTLY_INDEXED' |
+               'AllowLowTierReservedHwCbLimit'
+
+    RootConstants : 'RootConstants' '(' 'num32BitConstants' '=' NUMBER ','
+           bReg (',' 'space' '=' NUMBER)?
+           (',' 'visibility' '=' SHADER_VISIBILITY)? ')'
+
+    ROOT_DESCRIPTOR_FLAGS : 0 | 'DATA_STATIC' |
+                            'DATA_STATIC_WHILE_SET_AT_EXECUTE' |
+                            'DATA_VOLATILE'
+
+    RootCBV : 'CBV' '(' bReg (',' 'space' '=' NUMBER)?
+          (',' 'visibility' '=' SHADER_VISIBILITY)?
+          (',' 'flags' '=' ROOT_DESCRIPTOR_FLAGS)? ')'
+
+    RootSRV : 'SRV' '(' tReg (',' 'space' '=' NUMBER)?
+          (',' 'visibility' '=' SHADER_VISIBILITY)?
+          (',' 'flags' '=' ROOT_DESCRIPTOR_FLAGS)? ')'
+
+    RootUAV : 'UAV' '(' uReg (',' 'space' '=' NUMBER)?
+          (',' 'visibility' '=' SHADER_VISIBILITY)?
+          (',' 'flags' '=' ROOT_DESCRIPTOR_FLAGS)? ')'
+
+    DescriptorTable : 'DescriptorTable' '(' (DTClause(|DTClause)?)?
+          (',' 'visibility' '=' SHADER_VISIBILITY)? ')'
+
+    DTClause : CBV | SRV | UAV | Sampler
+
+    DESCRIPTOR_RANGE_FLAGS : DESCRIPTOR_RANGE_FLAGS(|DESCRIPTOR_RANGE_FLAGS)?
+
+    DESCRIPTOR_RANGE_FLAG : 0 |
+        'DESCRIPTORS_VOLATILE' |
+        'DATA_VOLATILE' |
+        'DATA_STATIC' |
+        'DATA_STATIC_WHILE_SET_AT_EXECUTE' |
+        'DESCRIPTORS_STATIC_KEEPING_BUFFER_BOUNDS_CHECKS'                          
+
+    CBV : 'CBV' '(' bReg (',' 'numDescriptors' '=' NUMBER)?
+          (',' 'space' '=' NUMBER)?
+          (',' 'offset' '=' DESCRIPTOR_RANGE_OFFSET)?
+          (',' 'flags' '=' DESCRIPTOR_RANGE_FLAGS)? ')'
+
+    SRV : 'SRV' '(' tReg (',' 'numDescriptors' '=' NUMBER)?
+          (',' 'space' '=' NUMBER)?
+          (',' 'offset' '=' DESCRIPTOR_RANGE_OFFSET)?
+          (',' 'flags' '=' DESCRIPTOR_RANGE_FLAGS)? ')'
+
+    UAV : 'UAV' '(' uReg (',' 'numDescriptors' '=' NUMBER)?
+          (',' 'space' '=' NUMBER)?
+          (',' 'offset' '=' DESCRIPTOR_RANGE_OFFSET)?
+          (',' 'flags' '=' DESCRIPTOR_RANGE_FLAGS)? ')'
+
+    Sampler : 'Sampler' '(' sReg (',' 'numDescriptors' '=' NUMBER)?
+          (',' 'space' '=' NUMBER)?
+          (',' 'offset' '=' DESCRIPTOR_RANGE_OFFSET)? (',' 'flags' '=' DESCRIPTOR_RANGE_FLAGS)? ')'
+
+    SHADER_VISIBILITY : 'SHADER_VISIBILITY_ALL' | 'SHADER_VISIBILITY_VERTEX' |
+                        'SHADER_VISIBILITY_HULL' |
+                        'SHADER_VISIBILITY_DOMAIN' |
+                        'SHADER_VISIBILITY_GEOMETRY' |
+                        'SHADER_VISIBILITY_PIXEL' |
+                        'SHADER_VISIBILITY_AMPLIFICATION' |
+                        'SHADER_VISIBILITY_MESH'
+
+    DESCRIPTOR_RANGE_OFFSET : 'DESCRIPTOR_RANGE_OFFSET_APPEND' | NUMBER
+
+    StaticSampler : 'StaticSampler' '(' sReg (',' 'filter' '=' FILTER)?
+             (',' 'addressU' '=' TEXTURE_ADDRESS)?
+             (',' 'addressV' '=' TEXTURE_ADDRESS)?
+             (',' 'addressW' '=' TEXTURE_ADDRESS)?
+             (',' 'mipLODBias' '=' NUMBER)?
+             (',' 'maxAnisotropy' '=' NUMBER)?
+             (',' 'comparisonFunc' '=' COMPARISON_FUNC)?
+             (',' 'borderColor' '=' STATIC_BORDER_COLOR)?
+             (',' 'minLOD' '=' NUMBER)?
+             (',' 'maxLOD' '=' NUMBER)? (',' 'space' '=' NUMBER)?
+             (',' 'visibility' '=' SHADER_VISIBILITY)? ')'
+  
+    bReg : 'b' NUMBER
+
+    tReg : 't' NUMBER
+
+    uReg : 'u' NUMBER
+
+    sReg : 's' NUMBER
+
+    FILTER : 'FILTER_MIN_MAG_MIP_POINT' |
+             'FILTER_MIN_MAG_POINT_MIP_LINEAR' |
+             'FILTER_MIN_POINT_MAG_LINEAR_MIP_POINT' |
+             'FILTER_MIN_POINT_MAG_MIP_LINEAR' |
+             'FILTER_MIN_LINEAR_MAG_MIP_POINT' |
+             'FILTER_MIN_LINEAR_MAG_POINT_MIP_LINEAR' |
+             'FILTER_MIN_MAG_LINEAR_MIP_POINT' |
+             'FILTER_MIN_MAG_MIP_LINEAR' |
+             'FILTER_ANISOTROPIC' |
+             'FILTER_COMPARISON_MIN_MAG_MIP_POINT' |
+             'FILTER_COMPARISON_MIN_MAG_POINT_MIP_LINEAR' |
+             'FILTER_COMPARISON_MIN_POINT_MAG_LINEAR_MIP_POINT' |
+             'FILTER_COMPARISON_MIN_POINT_MAG_MIP_LINEAR' |
+             'FILTER_COMPARISON_MIN_LINEAR_MAG_MIP_POINT' |
+             'FILTER_COMPARISON_MIN_LINEAR_MAG_POINT_MIP_LINEAR' |
+             'FILTER_COMPARISON_MIN_MAG_LINEAR_MIP_POINT' |
+             'FILTER_COMPARISON_MIN_MAG_MIP_LINEAR' |
+             'FILTER_COMPARISON_ANISOTROPIC' |
+             'FILTER_MINIMUM_MIN_MAG_MIP_POINT' |
+             'FILTER_MINIMUM_MIN_MAG_POINT_MIP_LINEAR' |
+             'FILTER_MINIMUM_MIN_POINT_MAG_LINEAR_MIP_POINT' |
+             'FILTER_MINIMUM_MIN_POINT_MAG_MIP_LINEAR' |
+             'FILTER_MINIMUM_MIN_LINEAR_MAG_MIP_POINT' |
+             'FILTER_MINIMUM_MIN_LINEAR_MAG_POINT_MIP_LINEAR' |
+             'FILTER_MINIMUM_MIN_MAG_LINEAR_MIP_POINT' |
+             'FILTER_MINIMUM_MIN_MAG_MIP_LINEAR' |
+             'FILTER_MINIMUM_ANISOTROPIC' |
+             'FILTER_MAXIMUM_MIN_MAG_MIP_POINT' |
+             'FILTER_MAXIMUM_MIN_MAG_POINT_MIP_LINEAR' |
+             'FILTER_MAXIMUM_MIN_POINT_MAG_LINEAR_MIP_POINT' |
+             'FILTER_MAXIMUM_MIN_POINT_MAG_MIP_LINEAR' |
+             'FILTER_MAXIMUM_MIN_LINEAR_MAG_MIP_POINT' |
+             'FILTER_MAXIMUM_MIN_LINEAR_MAG_POINT_MIP_LINEAR' |
+             'FILTER_MAXIMUM_MIN_MAG_LINEAR_MIP_POINT' |
+             'FILTER_MAXIMUM_MIN_MAG_MIP_LINEAR' |
+             'FILTER_MAXIMUM_ANISOTROPIC'
+
+    TEXTURE_ADDRESS : 'TEXTURE_ADDRESS_WRAP' |
+                      'TEXTURE_ADDRESS_MIRROR' | 'TEXTURE_ADDRESS_CLAMP' |
+                      'TEXTURE_ADDRESS_BORDER' | 'TEXTURE_ADDRESS_MIRROR_ONCE'
+
+    COMPARISON_FUNC : 'COMPARISON_NEVER' | 'COMPARISON_LESS' |
+                      'COMPARISON_EQUAL' | 'COMPARISON_LESS_EQUAL' |
+                      'COMPARISON_GREATER' | 'COMPARISON_NOT_EQUAL' |
+                      'COMPARISON_GREATER_EQUAL' | 'COMPARISON_ALWAYS'
+
+    STATIC_BORDER_COLOR : 'STATIC_BORDER_COLOR_TRANSPARENT_BLACK' |
+                          'STATIC_BORDER_COLOR_OPAQUE_BLACK' |
+                          'STATIC_BORDER_COLOR_OPAQUE_WHITE'
+```
+
+### Validation and Diagnostics
+
+As well as validating that the root signature is syntactically correct, the
+compiler must also validate that the shader is compatible with the root. For
+example, it must validate that the root signature binds each register that is
+used by the shader. Note that only resources referenced by the entry point need
+to be bound:
+
+```c++
+StructuredBuffer<float4> a : register(t0);
+StructuredBuffer<float4> b : register(t1);
+
+// valid
+[RootSignature("SRV(t0)")]
+float4 eg1() : SV_TARGET { return a[0]; }
+
+// invalid: b is bound to t1 that is not bound in the root signature.
+[RootSignature("SRV(t0)")]
+float4 eg2() : SV_TARGET { return b[0]; } 
+```
+
+## Proposed solution
+
+### Root Signatures in the AST
+
+A new attribute, `HLSLRootSignatureAttr` (defined in `Attr.td`), is added to
+capture the string defining the root signature. `AdditionalMembers` is used to
+add a member that holds the parsed representation of the root signature.
+
+Parsing of the root signature string happens in Sema, and some validation and
+diagnostics can be produced at this stage. For example:
+
+* is the root signature string syntactically correct?
+* is the specified root signature internally consistent?
+  * is the right type of register used in each parameter / descriptor range?
+* is each register bound only once?
+* see [Validations in Sema](#validations-in-sema) for full list
+
+The in-memory representation is guaranteed to be valid as far as the above
+checks are concerned.
+
+The root signature AST nodes are serialized / deserialized as normal bitcode.
+
+In the root signature DSL, a root signature is made up of a list of "root
+elements". The in-memory datastructures are designed around this concept where
+the RootSignature class is a vector of variants.
+
+Example:
+
+```c++
+RootSignature[
+ "RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT),"
+ "CBV(b0, space=1),"
+ "StaticSampler(s1),"
+ "DescriptorTable("
+ "  SRV(t0, numDescriptors=unbounded),"
+ "  UAV(u5, space=1, numDescriptors=10))"
+]
+```
+
+When parsed will produce a the equivalent of:
+
+```c++
+parsedRootSignature = RootSignature{
+  RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT),
+  RootCBV(0, 1), // register 0, space 1
+  StaticSampler(1, 0), // register 1, space 0
+  DescriptorTable({
+    SRV(0, 0, unbounded), // register 0, space 0, unbounded
+    UAV(5, 1, 10) // register 5, space 1, 10 descriptors
+  })
+};
+```
+
+### Root Signatures in the LLVM IR 
+
+During frontend code generation an IR-based representation of the root signature
+is generated from the in-memory data structures stored in the AST. This is
+stored as metadata nodes, identified by named metadata. The metadata format
+itself is a straightforward transcription of the in-memory data structure - so
+it is a list of root elements.
+
+See [Metadata Schema](#metadata-schema) for details.
+
+The IR schema has been designed so that many of the things that need to be
+validated during parsing can only be represented in valid way. For example, it
+is not possible to have an incorrect register type for a root parameter /
+descriptor range. However, it is possible to represent root signatures where
+registers are bound multiple times, or where there are multiple RootFlags
+entries, so subsequent stages should not assume that any given root signature in
+IR is valid.
+
+
+> **Open Question**: what should the named metadata be?  There's options I
+> think...
+
+Example for same root signature as above:
+
+```llvm
+; placeholder - update this once detailed design complete
+!directx.rootsignatures = !{!2}
+!2 = !{ptr @main, !3 }
+!3 = !{ !4, !5, !6, !7 } ; reference 4 root parameters
+!4 = !{ !"RootFlags", i32 1 } ; root flags, 1 is numeric value of flags
+!5 = !{ !"RootCBV", i32 0, i32 1, i32 0, i32 0 } ; register 0, space 1, 0 = visiblity, 0 = flags
+!6 = !{ !"StaticSampler", i32 1, i32 0, ... } ; register 1, space 0, (additional params omitted)
+!7 = !{ !"DescriptorTable", i32 0, !8, !9 } ;  0 = visibility, 2 ranges,!8 and !9
+!8 = !{ !"SRV", i32 0, i32 0, i32 -1, i32 0 } ; register 0, space 0, unbounded, flags 0
+!9 = !{ !"UAV", i32 5, i32 1, i32 10, i32 0 } ; register 5, space 1, 10 descriptors, flags 0
+```
+
+
+### Code Generation
+
+During backend code generation, the LLVM IR metadata representation of the root
+signature is converted data structures that represent the root signature that
+are more closely aligned to the final file format. For example, root parameters
+and static samplers can be intermingled in the previous formats, but are now
+separated into separate arrays at this point to aid in serializing.
+
+Example for same root signature as above:
+
+```c++
+// placeholder - update this once detailed design complete
+rootSignature = RootSignature(
+  ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT,
+  { // parameters
+    RootCBV(0, 1),
+    DescriptorTable({
+      SRV(0, 0, unbounded, 0),
+      UAV(5, 1, 10, 0)
+    })
+  },
+  { // static samplers
+    StaticSampler(1, 0)
+  });
+```
+
+At this point, final validation is performed to ensure that the root signature
+itself is valid. One key validation here is to check that each register is only
+bound once in the root signature. Even though this validation has been performed
+in the Clang frontend, we also need to support scenarios where the IR comes from
+other frontends and so the validation must be performed here as well.
+
+Once the root signature itself has been validated, validation is performed
+against the shader to ensure that any registers that the shader uses are bound
+in the root signature. This validation needs to occur after any dead-code
+elimation has completed.
+
+## Detailed design
+
+### Validations in Sema
+
+#### All the values should be legal.
+
+Most values like ShaderVisibility/ParameterType are covered by syntactical 
+checks in Sema.
+The additional semantic rules not already covered by the grammar are listed here.
+
+- For DESCRIPTOR_RANGE_FLAGS on a Sampler, only the following values are valid
+  - 0
+  - DESCRIPTORS_VOLATILE
+  - DESCRIPTORS_STATIC_KEEPING_BUFFER_BOUNDS_CHECKS
+
+- For DESCRIPTOR_RANGE_FLAGS on a CBV/SRV/UAV, only the following values are
+   valid
+  - 0
+  - DESCRIPTORS_VOLATILE
+  - DATA_VOLATILE
+  - DATA_STATIC
+  - DATA_STATIC_WHILE_SET_AT_EXECUTE
+  - DESCRIPTORS_VOLATILE | DATA_VOLATILE
+  - DESCRIPTORS_VOLATILE | DATA_STATIC_WHILE_SET_AT_EXECUTE
+  - DESCRIPTORS_STATIC_KEEPING_BUFFER_BOUNDS_CHECKS
+  - DESCRIPTORS_STATIC_KEEPING_BUFFER_BOUNDS_CHECKS | DATA_VOLATILE
+  - DESCRIPTORS_STATIC_KEEPING_BUFFER_BOUNDS_CHECKS | DATA_STATIC
+  - DESCRIPTORS_STATIC_KEEPING_BUFFER_BOUNDS_CHECKS | DATA_STATIC_WHILE_SET_AT_EXECUTE
+
+- StaticSampler
+  - Max/MinLOD cannot be NaN.
+  - MaxAnisotropy cannot exceed 16.
+  - MipLODBias must be within range of [-16, 15.99].
+
+- Register Space
+  -The range 0xFFFFFFF0 to 0xFFFFFFFF is reserved.
+  ```
+  "CBV(b0, space=4294967295)" is invalid due to the use of reserved space 0xFFFFFFFF.
+  ```
+
+- Resource ranges must not overlap.
+  ```
+  "CBV(b2), DescriptorTable(CBV(b0, numDescriptors=5))" will result in an error
+  due to overlapping at b2.
+  ```
+
+### Metadata Schema
+
+TODO
+
+### Validations during DXIL generation
+
+#### All the things validated in Sema.
+  All the validation rules mentioned in [Validations In Sema](#validations-in-sema)
+  need to be checked during DXIL generation as well.
+  The difference between checks in Sema and DXIL generation is that Sema could
+  rely on syntactical checks to validate values in many cases.
+  However, in DXIL generation, all values need to be checked to ensure they 
+  fall within the correct range:
+
+- RootFlags
+  - (RootFlags & 0x80000fff) should equals 0.
+
+- Valid values for ShaderVisibility
+  - SHADER_VISIBILITY_ALL
+  - SHADER_VISIBILITY_VERTEX
+  - SHADER_VISIBILITY_HULL
+  - SHADER_VISIBILITY_DOMAIN
+  - SHADER_VISIBILITY_GEOMETRY
+  - SHADER_VISIBILITY_PIXEL
+  - SHADER_VISIBILITY_AMPLIFICATION
+  - SHADER_VISIBILITY_MESH
+
+- Valid values for RootDescriptorFlags
+  - 0
+  - DataVolatile
+  - DataStaticWihleSetAtExecute
+  - DataStatic
+
+- Valid values for DescriptorRangeFlags on CBV/SRV/UAV
+  - 0
+  - DESCRIPTORS_VOLATILE
+  - DATA_VOLATILE
+  - DATA_STATIC
+  - DATA_STATIC_WHILE_SET_AT_EXECUTE
+  - DESCRIPTORS_VOLATILE | DATA_VOLATILE
+  - DESCRIPTORS_VOLATILE | DATA_STATIC_WHILE_SET_AT_EXECUTE
+  - DESCRIPTORS_STATIC_KEEPING_BUFFER_BOUNDS_CHECKS
+  - DESCRIPTORS_STATIC_KEEPING_BUFFER_BOUNDS_CHECKS | DATA_VOLATILE
+  - DESCRIPTORS_STATIC_KEEPING_BUFFER_BOUNDS_CHECKS | DATA_STATIC
+  - DESCRIPTORS_STATIC_KEEPING_BUFFER_BOUNDS_CHECKS | DATA_STATIC_WHILE_SET_AT_EXECUTE
+
+- Valid values for DescriptorRangeFlags on Sampler
+  - 0
+  - DESCRIPTORS_VOLATILE
+  - DESCRIPTORS_STATIC_KEEPING_BUFFER_BOUNDS_CHECKS
+
+- StaticSampler
+  - Valid values for Filter
+    - FILTER_MIN_MAG_MIP_POINT
+    - FILTER_MIN_MAG_POINT_MIP_LINEAR
+    - FILTER_MIN_POINT_MAG_LINEAR_MIP_POINT
+    - FILTER_MIN_POINT_MAG_MIP_LINEAR
+    - FILTER_MIN_LINEAR_MAG_MIP_POINT
+    - FILTER_MIN_LINEAR_MAG_POINT_MIP_LINEAR
+    - FILTER_MIN_MAG_LINEAR_MIP_POINT
+    - FILTER_MIN_MAG_MIP_LINEAR
+    - FILTER_ANISOTROPIC
+    - FILTER_COMPARISON_MIN_MAG_MIP_POINT
+    - FILTER_COMPARISON_MIN_MAG_POINT_MIP_LINEAR
+    - FILTER_COMPARISON_MIN_POINT_MAG_LINEAR_MIP_POINT
+    - FILTER_COMPARISON_MIN_POINT_MAG_MIP_LINEAR
+    - FILTER_COMPARISON_MIN_LINEAR_MAG_MIP_POINT
+    - FILTER_COMPARISON_MIN_LINEAR_MAG_POINT_MIP_LINEAR
+    - FILTER_COMPARISON_MIN_MAG_LINEAR_MIP_POINT
+    - FILTER_COMPARISON_MIN_MAG_MIP_LINEAR
+    - FILTER_COMPARISON_ANISOTROPIC
+    - FILTER_MINIMUM_MIN_MAG_MIP_POINT
+    - FILTER_MINIMUM_MIN_MAG_POINT_MIP_LINEAR
+    - FILTER_MINIMUM_MIN_POINT_MAG_LINEAR_MIP_POINT
+    - FILTER_MINIMUM_MIN_POINT_MAG_MIP_LINEAR
+    - FILTER_MINIMUM_MIN_LINEAR_MAG_MIP_POINT
+    - FILTER_MINIMUM_MIN_LINEAR_MAG_POINT_MIP_LINEAR
+    - FILTER_MINIMUM_MIN_MAG_LINEAR_MIP_POINT
+    - FILTER_MINIMUM_MIN_MAG_MIP_LINEAR
+    - FILTER_MINIMUM_ANISOTROPIC
+    - FILTER_MAXIMUM_MIN_MAG_MIP_POINT
+    - FILTER_MAXIMUM_MIN_MAG_POINT_MIP_LINEAR
+    - FILTER_MAXIMUM_MIN_POINT_MAG_LINEAR_MIP_POINT
+    - FILTER_MAXIMUM_MIN_POINT_MAG_MIP_LINEAR
+    - FILTER_MAXIMUM_MIN_LINEAR_MAG_MIP_POINT
+    - FILTER_MAXIMUM_MIN_LINEAR_MAG_POINT_MIP_LINEAR
+    - FILTER_MAXIMUM_MIN_MAG_LINEAR_MIP_POINT
+    - FILTER_MAXIMUM_MIN_MAG_MIP_LINEAR
+    - FILTER_MAXIMUM_ANISOTROPIC
+
+  - Valid values for TextureAddress
+    - TEXTURE_ADDRESS_WRAP 
+    - TEXTURE_ADDRESS_MIRROR  
+    - TEXTURE_ADDRESS_CLAMP 
+    - TEXTURE_ADDRESS_BORDER 
+    - TEXTURE_ADDRESS_MIRROR_ONCE
+
+  - Valid values for ComparisonFunc
+    - 0
+    - COMPARISON_NEVER 
+    - COMPARISON_LESS 
+    - COMPARISON_EQUAL 
+    - COMPARISON_LESS_EQUAL 
+    - COMPARISON_GREATER 
+    - COMPARISON_NOT_EQUAL 
+    - COMPARISON_GREATER_EQUAL 
+    - COMPARISON_ALWAYS
+
+  - Valid values for StaticBorderColor
+    - STATIC_BORDER_COLOR_TRANSPARENT_BLACK 
+    - STATIC_BORDER_COLOR_OPAQUE_BLACK 
+    - STATIC_BORDER_COLOR_OPAQUE_WHITE
+
+  - Comparison filter must have ComparisonFunc not equal to 0.
+      ```
+      When the Filter of a StaticSampler is FILTER_COMPARISON*,
+      the ComparisonFunc cannot be 0.
+      ```
+
+#### Resource used in DXIL must be fully bound in root signature.
+```
+  // B is bound to t1, but no root parameters cover t1.
+  Buffer<float> B : register(t1);
+  [RootSignature("")]
+  void main() : SV_Target {
+    return B[0];
+  }
+```
+
+#### Root Signature Flag must match DXIL.
+```
+  // Used dynamic resource but missing CBVSRVUAVHeapDirectlyIndexed flag.
+  [RootSignature("")]
+  void main() : SV_Target {
+    Buffer<float> B = ResourceDescriptorHeap[0];
+    return B[0];
+  }
+```
+
+#### Textures/TypedBuffers cannot be bound to root descriptors.
+```
+  // B is TypedBuffer, but bound as a root descriptor.
+  Buffer<float> B : register(t0);
+  [RootSignature("SRV(t0)")]
+  void main() : SV_Target {
+    return B[0];
+  }
+```
+
+
+<!--
+* Is there any potential for changed behavior?
+* Will this expose new interfaces that will have support burden?
+* How will this proposal be tested?
+* Does this require additional hardware/software/human resources?
+-->
+
+## Alternatives considered (Optional)
+
+### Store Root Signatures as Strings
+
+The root signature could be stored in its string form in the AST and in LLVM IR.
+There's a simplicity to this, and precedant with some other attributes. However,
+it does mean that there will be multiple places where the string needs to be
+parsed creating challenges for code organization as well as performance
+concerns.
+
+In addition, it unnecessarily ties all parts of the system with the current root
+signature DSL, which is something that should we [want to
+avoid](#note-on-the-root-signature-domain-specific-language).
+
+### Store Root Signatures in the serialized Direct3D format
+
+Direct3D specifies a serialized format for root signatures, that we will
+eventually need to generate in order to populate the DXBC container. One option
+would be to generate this early on and store it in the AST / IR.
+
+This approach was not chosen because the serialized format is not well suited to
+manipulation and storage in Clang/LLVM, it loses data (eg the language allow a
+"DESCRIPTOR_RANGE_OFFSET_APPEND" value that should be resolved in the serialized
+format).
+
+In addition, the specific serialized format is subject to change as the
+root signature specification evolves and it seems that this is something that
+Clang and LLVM should be decoupled from as much as possible.
+
+### Introduce a HLSLRootSignatureDecl
+
+Although the current design does not support HLSL state objects - specifically
+the `LocalRootSignature` and `GlobalRootSignature` subobjects - we could
+anticipate their needs and add a `HLSLRootSignatureDecl` that could be shared
+between `HLSLRootSignatureAttr` and whatever AST nodes are introduces for these
+subojects. The problem is that we'd need to design pretty much the entire HLSL
+state objects feature to do this properly. Instead, we chose to build a complete
+feature without state object support and accept that some refactoring in this
+area may be necessary to share code between root signatures in attributes and
+root signatures in subojects.
+
+### Deduplicate root signatures
+
+It's possible that the same root signature string could be presented to the
+compiler multiple times. An extra layer of indirection in the parsing code could
+allow us to avoid parsing the root signature multiple times.
+
+As this would strictly be an optimization and isn't required for correctness,
+this is something that will be considered if profiling shows us that
+* multiple duplicate root signatures is a common scenario and
+* parsing them takes a significant amount of time.
+
+### Reused / share D3D code
+
+We could conceivably just use the D3D12 `D3D12_VERSIONED_ROOT_SIGNATURE_DESC`
+datastructures for this, rather than building our own parallel versions. Also,
+we could even try and get D3D's serialization code open-sourced so we don't need
+to maintain multiple implementations of it. This doesn't mesh well with LLVM
+since it would be adding external dependencies. We would also need to ensure
+that LLVM can be built in all the host environments it supports - this means
+binary dependencies are not viable, and any existing code would likely need to
+be reworked so much for portability and comformance with LLVM coding conventions
+that the effort would not be worthwhile.
+
+
+
+## Acknowledgments (Optional)
+
+
+<!-- {% endraw %} -->


### PR DESCRIPTION
This change adds copies of the infrastructure proposals from https://github.com/microsoft/hlsl-specs that are describing clang/llvm implementation details.