### PR TITLE
Add metadata schema to root signature

### DIFF
--- a/proposals/0002-root-signature-in-clang.md
+++ b/proposals/0002-root-signature-in-clang.md
@@ -554,9 +554,7 @@ The additional semantic rules not already covered by the grammar are listed here
 
 | Property       | Type              | Type detail                                         |
 | -------------- | ----------------- | --------------------------------------------------- |
-| RootFlag       | i32               | D3D12_ROOT_SIGNATURE_FLAG                           |
-| Parameters     | reference to list | list of RootDescriptor/RootConstant/DescriptorTable |
-| StaticSamplers | reference to list | list of StaticSamplers                              |
+| Parameters     | reference to list | list of  D3D12_ROOT_SIGNATURE_FLAG/RootDescriptor/RootConstant/DescriptorTable/StaticSamplers |
 
 * Function RootSignature pair
 
@@ -579,15 +577,12 @@ Example for same root signature as above:
 ; placeholder - update this once detailed design complete
 !dx.rootsignatures = !{!2}
 !2 = !{ptr @main, !3 }
-!3 = !{ i32 1, !4, !10 } ; RootFlags, Parameters, StaticSamplers
-!4 = !{!5, !6} ; list of RootDescriptor/RootConstant/DescriptorTable
-!5 = !{ !"RootCBV", i32 0, i32 1, i32 0, i32 0 } ; register 0, space 1, 0 = visiblity, 0 = flags
-!6 = !{ !"DescriptorTable", i32 0, !7 } ;  0 = visibility, range list !7
-!7 = !{ !8, !9} ; reference 2 descriptor ranges
-!8 = !{ !"SRV", i32 0, i32 0, i32 -1, i32 0 } ; register 0, space 0, unbounded, flags 0
-!9 = !{ !"UAV", i32 5, i32 1, i32 10, i32 0 } ; register 5, space 1, 10 descriptors, flags 0
-!10 = !{!11} ; list of StaticSamplers
-!11 = !{ !"StaticSampler", i32 1, i32 0, ... } ; register 1, space 0, (additional params omitted)
+!3 = !{ i32 1, !4, !5, !6, !7, !8 } ; RootFlags, Parameters, StaticSamplers
+!4 = !{ !"RootCBV", i32 0, i32 1, i32 0, i32 0 } ; register 0, space 1, 0 = visiblity, 0 = flags
+!5 = !{ !"DescriptorTable", i32 0, !7 } ;  0 = visibility, range list !7
+!6 = !{ !"SRV", i32 0, i32 0, i32 -1, i32 0 } ; register 0, space 0, unbounded, flags 0
+!7 = !{ !"UAV", i32 5, i32 1, i32 10, i32 0 } ; register 5, space 1, 10 descriptors, flags 0
+!8 = !{ !"StaticSampler", i32 1, i32 0, ... } ; register 1, space 0, (additional params omitted)
 ```
 
 ### Validations during DXIL generation

--- a/proposals/0002-root-signature-in-clang.md
+++ b/proposals/0002-root-signature-in-clang.md
@@ -554,7 +554,7 @@ The additional semantic rules not already covered by the grammar are listed here
 
 | Property       | Type              | Type detail                                         |
 | -------------- | ----------------- | --------------------------------------------------- |
-| Root elements  | reference to list | list of  D3D12_ROOT_SIGNATURE_FLAG/RootDescriptor/RootConstant/DescriptorTable/StaticSamplers |
+| Root elements  | reference to list | list of root elements|
 
 * Function RootSignature pair
 

--- a/proposals/0002-root-signature-in-clang.md
+++ b/proposals/0002-root-signature-in-clang.md
@@ -554,7 +554,7 @@ The additional semantic rules not already covered by the grammar are listed here
 
 | Property       | Type              | Type detail                                         |
 | -------------- | ----------------- | --------------------------------------------------- |
-| Parameters     | reference to list | list of  D3D12_ROOT_SIGNATURE_FLAG/RootDescriptor/RootConstant/DescriptorTable/StaticSamplers |
+| Root elements  | reference to list | list of  D3D12_ROOT_SIGNATURE_FLAG/RootDescriptor/RootConstant/DescriptorTable/StaticSamplers |
 
 * Function RootSignature pair
 

--- a/proposals/0002-root-signature-in-clang.md
+++ b/proposals/0002-root-signature-in-clang.md
@@ -402,23 +402,75 @@ registers are bound multiple times, or where there are multiple RootFlags
 entries, so subsequent stages should not assume that any given root signature in
 IR is valid.
 
+#### Metadata Schema
 
-> **Open Question**: what should the named metadata be?  There's options I
-> think...
+* RootConstant
+
+| ParameterType | ShaderVisibility | ShaderRegister | RegisterSpace | Num32BitValues |
+|---------------|------------------|----------------|---------------|----------------|
+| String        | int              | int            | int           | int            |
+
+
+* RootDescriptor
+
+| ParameterType | ShaderVisibility | ShaderRegister | RegisterSpace | RootDescriptorFlags |
+|---------------|------------------|----------------|---------------|---------------------|
+| String        | int              | int            | int           | int                 |
+
+
+* DescriptorRange
+
+| RangeType | NumDescriptors | BaseShaderRegister | RegisterSpace | DescriptorRangeFlags |
+|-----------|----------------|--------------------|---------------|----------------------|
+| String    | int            | int                | int           | int                  |
+
+
+* DescriptorTable
+
+| DescriptorRanges          |
+|---------------------------|
+| list of DescriptorRanges  |
+
+* StaticSampler
+  
+| Filter | AddressU | AddressV | AddressW | MipLODBias | MaxAnisotropy | ComparisonFunc | BorderColor | MinLOD | MaxLOD | ShaderRegister | RegisterSpace | ShaderVisibility |
+|--------|----------|----------|----------|------------|---------------|----------------|-------------|--------|--------|----------------|---------------|------------------|
+| int    | int      | int      | int      | float      | int           | int            | int         | float  | float  | int            | int           | int              |
+
+* RootSignature
+
+| RootFlag | Parameters                                      | StaticSamplers          |
+|----------|-------------------------------------------------|-------------------------|
+| int      | list of RootDescriptor/RootConstant/DescriptorTable | list of StaticSamplers |
+
+* Function RootSignature pair
+
+| EntryFunction | RootSignature |
+|----------|----------------|
+| Function | RootSignature  |
+
+* RootSignature table
+
+Named metadata with name "dx.rootsignatures".
+
+| Function RootSignature Pairs |
+|-------------------------------------|
+| list of Function RootSignature Pair |
 
 Example for same root signature as above:
 
 ```llvm
 ; placeholder - update this once detailed design complete
-!directx.rootsignatures = !{!2}
+!dx.rootsignatures = !{!2}
 !2 = !{ptr @main, !3 }
 !3 = !{ !4, !5, !6, !7 } ; reference 4 root parameters
 !4 = !{ !"RootFlags", i32 1 } ; root flags, 1 is numeric value of flags
 !5 = !{ !"RootCBV", i32 0, i32 1, i32 0, i32 0 } ; register 0, space 1, 0 = visiblity, 0 = flags
 !6 = !{ !"StaticSampler", i32 1, i32 0, ... } ; register 1, space 0, (additional params omitted)
-!7 = !{ !"DescriptorTable", i32 0, !8, !9 } ;  0 = visibility, 2 ranges,!8 and !9
-!8 = !{ !"SRV", i32 0, i32 0, i32 -1, i32 0 } ; register 0, space 0, unbounded, flags 0
-!9 = !{ !"UAV", i32 5, i32 1, i32 10, i32 0 } ; register 5, space 1, 10 descriptors, flags 0
+!7 = !{ !"DescriptorTable", i32 0, !8 } ;  0 = visibility, range list !8
+!8 = !{ !9, !10} ; reference 2 descriptor ranges
+!9 = !{ !"SRV", i32 0, i32 0, i32 -1, i32 0 } ; register 0, space 0, unbounded, flags 0
+!10 = !{ !"UAV", i32 5, i32 1, i32 10, i32 0 } ; register 5, space 1, 10 descriptors, flags 0
 ```
 
 

--- a/proposals/0002-root-signature-in-clang.md
+++ b/proposals/0002-root-signature-in-clang.md
@@ -536,6 +536,7 @@ The additional semantic rules not already covered by the grammar are listed here
 
 | Property         | Type  | Type detail                |
 | ---------------- | ----- | -------------------------- |
+| ParameterType    | string| "StaticSampler"            |
 | Filter           | i32   | D3D12_FILTER               |
 | AddressU         | i32   | D3D12_TEXTURE_ADDRESS_MODE |
 | AddressV         | i32   | D3D12_TEXTURE_ADDRESS_MODE |


### PR DESCRIPTION
This commit adds a metadata schema to the root signature.
This schema is used to describe the root signature in llvm IR.