### PR TITLE
[0005] Mark out of process compiler api proposal as Accepted

### DIFF
--- a/proposals/0005-inproc-outofproc-compiler-api-support.md
+++ b/proposals/0005-inproc-outofproc-compiler-api-support.md
@@ -5,7 +5,7 @@
 * Proposal: [0005](0005-inproc-outofproc-compiler-api-support.md)
 * Author(s): [Cooper Partin](https://github.com/coopp)
 * Sponsor: [Cooper Partin](https://github.com/coopp)
-* Status: **Under Consideration**
+* Status: **Accepted**
 * Impacted Project(s): (Clang)
 
 * Issues:


### PR DESCRIPTION
This commit updates the proposal to be in an 'Accepted' state.  A team meeting happened where we all agreed on this approach.