### PR TITLE
tools/hlslpm: always get issue titles, and don't accept things that aren't issue references in section titles

### DIFF
--- a/tools/hlslpm/github.py
+++ b/tools/hlslpm/github.py
@@ -65,7 +65,6 @@ class GH:
             nodes = maybe_get(response, "data", "nodes")
             for (issue, node) in zip(chunk, nodes):
                 issue.body = node["body"]
-                yield issue
 
     def set_issue_body(self, id, body):
         query = read_file_relative_to_this_script("gql/set_issue_body.gql")

--- a/tools/hlslpm/github.py
+++ b/tools/hlslpm/github.py
@@ -51,7 +51,7 @@ class GH:
 
             pageInfo = maybe_get(items, 'pageInfo')
 
-    def populate_issues_title(self, issues: List[Issue]):
+    def populate_issues_body(self, issues: List[Issue]):
         query = read_file_relative_to_this_script("gql/get_issue_text.gql")
         chunk_size = 50
 
@@ -123,7 +123,7 @@ if __name__ == '__main__':
         interesting = [i for i in items_summary if i.category ==
                        Category.ProjectMilestone or i.category == Category.Workstream]
 
-        gh.populate_issues_title(interesting)
+        gh.populate_issues_body(interesting)
 
         milestones = [i for i in interesting if i.category ==
                       Category.ProjectMilestone]
@@ -141,7 +141,7 @@ if __name__ == '__main__':
 
     if False:
         issues = [Issue(issue_id="I_kwDOMbLzis6Rpmkm")]
-        gh.populate_issues_title(issues)
+        gh.populate_issues_body(issues)
 
         for i in issues:
             print(f"Title: {i.title}")

--- a/tools/hlslpm/gql/get_issue_text.gql
+++ b/tools/hlslpm/gql/get_issue_text.gql
@@ -1,7 +1,7 @@
 query($issueIds: [ID!]!) {
     nodes(ids: $issueIds) {
         ... on Issue {
-            title body
+            body
         }
     }
 }

--- a/tools/hlslpm/gql/project_item_summary.gql
+++ b/tools/hlslpm/gql/project_item_summary.gql
@@ -8,7 +8,7 @@ query($after: String) {
                         ... on ProjectV2ItemFieldSingleSelectValue { name } }
                     target:fieldValueByName(name: "Target") { 
                         ... on ProjectV2ItemFieldDateValue { date } }
-                    content { ... on Issue { id updatedAt resourcePath } }
+                    content { ... on Issue { id updatedAt resourcePath title } }
                 }
                 pageInfo { endCursor hasNextPage }
             }

--- a/tools/hlslpm/issue.py
+++ b/tools/hlslpm/issue.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, date
 from enum import Enum
 import re
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Self, Union
 import json
 
 class Category(Enum):
@@ -27,7 +27,7 @@ class IssueSection:
         if not self.title:
             return None
 
-        m = re.match(r".*\((.+)\)", self.title)
+        m = re.match(r".*\((.*#\d+)\)", self.title)
         if not m:
             return None
         
@@ -201,15 +201,22 @@ class Issue:
         return section
 
 
-    def buildSectionTitle(self, issue):
-        m = re.match(r"\[.*\](.*)", issue.title)
-        if m:
-            title = m[1].strip()
-        else:
-            title = issue.title
+    def buildSectionTitle(self, issue:Self):
+        try:
+            if issue.title == None:
+                return "Issue has no title - maybe draft?"
 
-        return f"{title} ({issue.getIssueReference(self)})"
-    
+            m = re.match(r"\[.*\](.*)", issue.title)
+            if m:
+                title = m[1].strip()
+            else:
+                title = issue.title
+
+            return f"{title} ({issue.getIssueReference(self)})"
+        except:
+            print(f"Exception working on issue {issue} {issue.issue_id} {issue.issue_resourcePath}")
+            raise
+                                                    
     def getContentsFor(self, issue) -> List[str]:
         (_, data, _) = split_body(self.body)
         data = parse_data(data)

--- a/tools/hlslpm/issue.py
+++ b/tools/hlslpm/issue.py
@@ -203,9 +203,6 @@ class Issue:
 
     def buildSectionTitle(self, issue:Self):
         try:
-            if issue.title == None:
-                return "Issue has no title - maybe draft?"
-
             m = re.match(r"\[.*\](.*)", issue.title)
             if m:
                 title = m[1].strip()

--- a/tools/hlslpm/issue.py
+++ b/tools/hlslpm/issue.py
@@ -27,11 +27,10 @@ class IssueSection:
         if not self.title:
             return None
 
-        m = re.match(r".*\((.*#\d+)\)", self.title)
-        if not m:
-            return None
+        if m := re.match(r".*\((.*#\d+)\)", self.title):
+            return m[1]
         
-        return m[1]
+        return None
     
 
 class IssueData:

--- a/tools/hlslpm/issue.py
+++ b/tools/hlslpm/issue.py
@@ -27,7 +27,7 @@ class IssueSection:
         if not self.title:
             return None
 
-        m = re.match(".*\((.+)\)", self.title)
+        m = re.match(r".*\((.+)\)", self.title)
         if not m:
             return None
         

--- a/tools/hlslpm/issue.py
+++ b/tools/hlslpm/issue.py
@@ -323,6 +323,7 @@ class Issues:
     all_issues: Dict[str, Issue]
     milestones: List[Issue]
     workstreams: List[Issue]
+    tracked_issues_not_in_project: List[str]
 
     def __init__(self, gh):
         def is_interesting(i: Issue):
@@ -333,7 +334,7 @@ class Issues:
 
         interesting = [i for i in self.all_issues.values()
                        if is_interesting(i)]
-        interesting = [i for i in gh.get_issues(interesting)]
+        gh.populate_issues_title(interesting)
 
         self.milestones = [i for i in interesting if i.category == Category.ProjectMilestone]
         self.workstreams = [i for i in interesting if i.category == Category.Workstream]

--- a/tools/hlslpm/issue.py
+++ b/tools/hlslpm/issue.py
@@ -334,7 +334,7 @@ class Issues:
 
         interesting = [i for i in self.all_issues.values()
                        if is_interesting(i)]
-        gh.populate_issues_title(interesting)
+        gh.populate_issues_body(interesting)
 
         self.milestones = [i for i in interesting if i.category == Category.ProjectMilestone]
         self.workstreams = [i for i in interesting if i.category == Category.Workstream]

--- a/tools/hlslpm/testIssues.py
+++ b/tools/hlslpm/testIssues.py
@@ -87,9 +87,8 @@ class Test_Issues(unittest.TestCase):
                 for i in self.issues:
                     yield i
 
-            def get_issues(self, issues):
-                for i in issues:
-                    yield i
+            def populate_issues_title(self, issues):
+                pass
 
         gh = GH(list(self.test_issues.values()))
 

--- a/tools/hlslpm/testIssues.py
+++ b/tools/hlslpm/testIssues.py
@@ -87,7 +87,7 @@ class Test_Issues(unittest.TestCase):
                 for i in self.issues:
                     yield i
 
-            def populate_issues_title(self, issues):
+            def populate_issues_body(self, issues):
                 pass
 
         gh = GH(list(self.test_issues.values()))

--- a/tools/hlslpm/testIssues.py
+++ b/tools/hlslpm/testIssues.py
@@ -63,7 +63,7 @@ class Test_Issues(unittest.TestCase):
         test_issues = [(1, Category.ProjectMilestone, date(2024, 1, 1), "[milestone] The First Milestone", ["About the milestone.", "## Workstreams",
                         "### WorkstreamA (#2)", "foo", "bar", "### Workstream B(#3)", "com", "baz"]),
                        (2, Category.Workstream, None, "[workstream] Super fast workstream",
-                        ["About the workstream.", "## Milestones", "### Milestone 1 (#1)", "- [ ] item1", "- [ ] item2"]),
+                        ["About the workstream.", "## Milestones", "### Milestone 1 (#1)", "- [ ] item1", "- [ ] item2", "", "### Random Stuff(??)", "Foo"]),
                        (3, Category.Workstream, None, "[workstream] Super slow workstream",
                         ["Taking it easy.", "## Milestones", "### Milestone 1 (#1)", "- [ ] item3"]),
                        (4, Category.Workstream, None,
@@ -133,7 +133,7 @@ class Test_Issues(unittest.TestCase):
         workstream.update(self.issues)
 
         self.assertEqual(["About the workstream.", "## Milestones", "### The First Milestone (#1)",
-                         "- [ ] item1", "- [ ] item2"], workstream.body.splitlines())
+                         "- [ ] item1", "- [ ] item2", "", "### Random Stuff(??)", "Foo"], workstream.body.splitlines())
 
     def test_UpdateEmptyWorkstream(self):
         issue = getByResourcePath(self.issues.workstreams, "test/issues/4")


### PR DESCRIPTION
Previously, this would blindly accept something like `### Foo (??)` as a section heading referring to an issue with reference `??`.  Various things fell over after this, so this change instead only accepts things that look like github-style issues references.

Also included in this change is the infrastructure added to help track down this issue - namely, grabbing more information about each issue and displaying information about that when something goes wrong.
