### PR TITLE
Add responsibility of space parameter validation to DiagnoseHLSLRegisterAttribute

### DIFF
--- a/proposals/0004-register-types-and-diagnostics.md
+++ b/proposals/0004-register-types-and-diagnostics.md
@@ -59,7 +59,8 @@ compatible with the Decl. All of this analysis and validation will be executed
 inside a new function, `DiagnoseHLSLRegisterAttribute`. This function will be
 responsible for validating the semantic meaning behind the application of the
 attribute, while the rest of `handleResourceBindingAttr` is responsible for
-validating the syntax of the attribute. 
+validating the syntax of the attribute.
+
 The `register` annotation may also have a second parameter, `spaceN`, where `N` is 
 some integer. `DiagnoseHLSLRegisterAttribute` will also be responsible for validating 
 that the `space` parameter is never specified on a global constant.

--- a/proposals/0004-register-types-and-diagnostics.md
+++ b/proposals/0004-register-types-and-diagnostics.md
@@ -59,7 +59,10 @@ compatible with the Decl. All of this analysis and validation will be executed
 inside a new function, `DiagnoseHLSLRegisterAttribute`. This function will be
 responsible for validating the semantic meaning behind the application of the
 attribute, while the rest of `handleResourceBindingAttr` is responsible for
-validating the syntax of the attribute.
+validating the syntax of the attribute. 
+The `register` annotation may also have a second parameter, `spaceN`, where `N` is 
+some integer. `DiagnoseHLSLRegisterAttribute` will also be responsible for validating 
+that the `space` parameter is never specified on a global constant.
 
 ### Recognized Register Types
 
@@ -208,8 +211,8 @@ float f : register(i0);
 //
 ```
 
-In DXC, the analysis and diagnostic emission steps would happen in DiagnoseRegisterType(),
-under DiagnoseHLSLDecl in SemaHLSL.cpp. In clang, there is a function called in
+In DXC, the analysis and diagnostic emission steps would happen in `DiagnoseRegisterType()`,
+under `DiagnoseHLSLDecl` in `SemaHLSL.cpp`. In clang, there is a function called in
 `clang\lib\Sema\SemaDeclAttr.cpp` named `handleResourceBindingAttr` that is responsible for
 diagnosing and validating the `register` keyword when it is applied to any decl. Any time the
 `register` annotation is applied on a decl, the `AT_HLSLResourceBinding` attribute gets added

--- a/proposals/0004-register-types-and-diagnostics.md
+++ b/proposals/0004-register-types-and-diagnostics.md
@@ -62,8 +62,9 @@ attribute, while the rest of `handleResourceBindingAttr` is responsible for
 validating the syntax of the attribute.
 
 The `register` annotation may also have a second parameter, `spaceN`, where `N` is 
-some integer. `DiagnoseHLSLRegisterAttribute` will also be responsible for validating 
-that the `space` parameter is never specified on a global constant.
+some integer between 0 and 42949672879. `DiagnoseHLSLRegisterAttribute` will also 
+be responsible for validating that the `space` parameter is never specified on a 
+global constant.
 
 ### Recognized Register Types
 


### PR DESCRIPTION
The `space` parameter will also be validated in `DiagnoseHLSLRegisterAttribute`, and is worth mentioning in the spec.