### PR TITLE
[hlslpm] Add command to update ProjectMilestone fields

### DIFF
--- a/tools/hlslpm/gql/get_issues_tracked.gql
+++ b/tools/hlslpm/gql/get_issues_tracked.gql
@@ -1,0 +1,12 @@
+query($issueIds: [ID!]!, $numIssuesToGet: Int!, $after: String) {
+    nodes(ids: $issueIds) {
+        ... on Issue {
+            trackedIssues(first: $numIssuesToGet, after: $after) {
+                nodes {
+                    id
+                }
+                pageInfo { endCursor hasNextPage }
+            }
+        }
+    }
+}

--- a/tools/hlslpm/gql/get_project_field_id.gql
+++ b/tools/hlslpm/gql/get_project_field_id.gql
@@ -1,0 +1,18 @@
+query ($project: String!, $projectNumber: Int!, $fieldName: String!) {
+  organization(login: $project) {
+    projectV2(number: $projectNumber) {
+      id
+      field(name: $fieldName) {
+        ... on ProjectV2FieldCommon {
+          id
+        }
+        ... on ProjectV2SingleSelectField {
+          options {
+            name
+            id
+          }
+        }
+      }
+    }
+  }
+}

--- a/tools/hlslpm/gql/project_item_summary.gql
+++ b/tools/hlslpm/gql/project_item_summary.gql
@@ -8,7 +8,11 @@ query($after: String) {
                         ... on ProjectV2ItemFieldSingleSelectValue { name } }
                     target:fieldValueByName(name: "Target") { 
                         ... on ProjectV2ItemFieldDateValue { date } }
-                    content { ... on Issue { id updatedAt resourcePath title } }
+                    workstream:fieldValueByName(name: "Workstream") {
+                        ... on ProjectV2ItemFieldSingleSelectValue { name } }
+                    projectMilestone:fieldValueByName(name: "ProjectMilestone") {
+                        ... on ProjectV2ItemFieldSingleSelectValue { name } }
+                    content { ... on Issue { id updatedAt resourcePath title state } }
                 }
                 pageInfo { endCursor hasNextPage }
             }

--- a/tools/hlslpm/gql/set_issue_project_milestone.gql
+++ b/tools/hlslpm/gql/set_issue_project_milestone.gql
@@ -1,0 +1,17 @@
+mutation (
+  $projectId: ID!
+  $itemId: ID!
+  $fieldId: ID!
+  $projectMilestone: String!
+) {
+  updateProjectV2ItemFieldValue(
+    input: {
+      projectId: $projectId
+      itemId: $itemId
+      fieldId: $fieldId
+      value: { singleSelectOptionId: $projectMilestone }
+    }
+  ) {
+    clientMutationId
+  }
+}

--- a/tools/hlslpm/hlslpm.py
+++ b/tools/hlslpm/hlslpm.py
@@ -1,11 +1,11 @@
 # Main entry point for tool that mangages the HLSL Project on llvm.
 
-import sys
 from argparse import ArgumentParser
 import os
 from typing import List
 from issue import Issue, Issues
 import github
+from updateMilestoneField import updateMilestoneField_addArgs
 
 
 def saveIssues(basePath, issues: List[Issue]):
@@ -21,12 +21,12 @@ def saveIssues(basePath, issues: List[Issue]):
 def updateIssues_addArgs(subparsers):
     parser: ArgumentParser = subparsers.add_parser(
         'update-issues', aliases=['ui'])
-    
+
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--save', action='store_true',
-                        help="Saves before/after issues")
+                       help="Saves before/after issues")
     group.add_argument('--commit', action='store_true',
-                        help="Commit changes to the github issues")
+                       help="Commit changes to the github issues")
     parser.set_defaults(func=updateIssues)
 
 
@@ -55,10 +55,12 @@ def updateIssues(args):
 
     for id in bodyBefore.keys():
         if bodyBefore[id] != bodyAfter[id]:
-            print(f"{id} changed!")
+            print(
+                f"{issues.all_issues_by_id[id].getIssueReference()} body changed!")
 
-            if args.update:
+            if args.commit:
                 gh.set_issue_body(id, bodyAfter[id])
+
 
 
 if __name__ == '__main__':
@@ -68,6 +70,7 @@ if __name__ == '__main__':
     subparsers = parser.add_subparsers(
         required=True, title="subcommands", description="valid subcommands", help="additional help")
     updateIssues_addArgs(subparsers)
+    updateMilestoneField_addArgs(subparsers)
 
     args = parser.parse_args()
 

--- a/tools/hlslpm/issue.py
+++ b/tools/hlslpm/issue.py
@@ -63,6 +63,9 @@ class Issue:
     tracked_issues: List[Self] = field(default_factory=list)
     tracked_by_issues: List[Self] = field(default_factory=list)
 
+    def __repr__(self):
+        return f"{self.getIssueReference()}"
+    
     def getResourcePathBase(self):
         m = re.match(r"(.*)/\d+", self.issue_resourcePath)
         if not m:

--- a/tools/hlslpm/updateMilestoneField.py
+++ b/tools/hlslpm/updateMilestoneField.py
@@ -1,9 +1,11 @@
 # Makes sure that the ProjectMilestone fields are set correctly
 from argparse import ArgumentParser
-from typing import Dict
+import itertools
+from typing import Dict, List, Set
 
 import github
-from issue import Issues
+from issue import Category, Issue, Issues
+
 
 def updateMilestoneField_addArgs(subparsers):
     parser: ArgumentParser = subparsers.add_parser(
@@ -14,29 +16,29 @@ def updateMilestoneField_addArgs(subparsers):
                        help='Commit changes to the github issues')
     parser.set_defaults(func=updateMilestoneField)
 
+
 def updateMilestoneField(args):
     print("Fetching data...")
-    gh = github.GH();
+    gh = github.GH()
     issues = Issues(gh)
-    
-    # key: issue (id) we've seen
-    # value: the milestone issue (id) associated with it
-    seen:Dict[str, str] = dict()
+
+    seen: Set[str] = set()
+    multipleParents: Set[str] = set()
 
     all = issues.all_issues_by_id
 
     def recursivelySetProjectMilestone(issue_id: str, milestoneIssue_id: str):
+        if issue_id in seen:
+            multipleParents.add(issue_id)
+            return
+        seen.add(issue_id)
+
         issue = all[issue_id]
         milestoneIssue = all[milestoneIssue_id]
 
-        if issue_id in seen:        
-            seenIssue = all[seen[issue_id]]
-            print(f"WARNING: {issue.getIssueReference()} seen under both {milestoneIssue.getIssueReference()} and {seenIssue.getIssueReference()}")
-            return
-
-        seen[issue_id] = milestoneIssue_id
         if issue.projectMilestone != milestoneIssue.projectMilestone:
-            print(f"{issue.getIssueReference()}: {issue.projectMilestone} --> {milestoneIssue.projectMilestone}")
+            print(f"{issue.getIssueReference()}: {
+                  issue.projectMilestone} --> {milestoneIssue.projectMilestone}")
             issue.projectMilestone = milestoneIssue.projectMilestone
             if args.commit:
                 gh.set_project_milestone(issue.item_id, issue.projectMilestone)
@@ -44,8 +46,37 @@ def updateMilestoneField(args):
         for child in issue.tracked_issues:
             recursivelySetProjectMilestone(child.issue_id, milestoneIssue_id)
 
-
-
     for i in issues.milestones:
         recursivelySetProjectMilestone(i.issue_id, i.issue_id)
 
+    for i in multipleParents:
+        reportMultipleParents(issues, i)
+
+
+def reportMultipleParents(issues: Issues, issue_id):
+    issue = issues.all_issues_by_id[issue_id]
+
+    print(f"{issue.getIssueReference()} {
+          issue.title} - is in multiple milestones:")
+
+    def findPathsToMilestone(path: List[Issue], paths: List[Issue]):
+        if path[-1].category == Category.ProjectMilestone:
+            paths.append(path)
+            return
+
+        for i in path[-1].tracked_by_issues:
+            findPathsToMilestone(path + [i], paths)
+
+    paths:List[List[Issue]] = []
+    findPathsToMilestone([issue], paths)
+
+    for p in paths:
+        p.reverse()
+        print(f"    {" -> ".join([i.getIssueReference() for i in p])}")
+    print("")
+
+
+if __name__ == "__main__":
+    class Args:
+        commit = False
+    updateMilestoneField(Args())

--- a/tools/hlslpm/updateMilestoneField.py
+++ b/tools/hlslpm/updateMilestoneField.py
@@ -1,0 +1,51 @@
+# Makes sure that the ProjectMilestone fields are set correctly
+from argparse import ArgumentParser
+from typing import Dict
+
+import github
+from issue import Issues
+
+def updateMilestoneField_addArgs(subparsers):
+    parser: ArgumentParser = subparsers.add_parser(
+        'update-milestone-field', aliases=['umf'])
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--commit', action='store_true',
+                       help='Commit changes to the github issues')
+    parser.set_defaults(func=updateMilestoneField)
+
+def updateMilestoneField(args):
+    print("Fetching data...")
+    gh = github.GH();
+    issues = Issues(gh)
+    
+    # key: issue (id) we've seen
+    # value: the milestone issue (id) associated with it
+    seen:Dict[str, str] = dict()
+
+    all = issues.all_issues_by_id
+
+    def recursivelySetProjectMilestone(issue_id: str, milestoneIssue_id: str):
+        issue = all[issue_id]
+        milestoneIssue = all[milestoneIssue_id]
+
+        if issue_id in seen:        
+            seenIssue = all[seen[issue_id]]
+            print(f"WARNING: {issue.getIssueReference()} seen under both {milestoneIssue.getIssueReference()} and {seenIssue.getIssueReference()}")
+            return
+
+        seen[issue_id] = milestoneIssue_id
+        if issue.projectMilestone != milestoneIssue.projectMilestone:
+            print(f"{issue.getIssueReference()}: {issue.projectMilestone} --> {milestoneIssue.projectMilestone}")
+            issue.projectMilestone = milestoneIssue.projectMilestone
+            if args.commit:
+                gh.set_project_milestone(issue.item_id, issue.projectMilestone)
+
+        for child in issue.tracked_issues:
+            recursivelySetProjectMilestone(child.issue_id, milestoneIssue_id)
+
+
+
+    for i in issues.milestones:
+        recursivelySetProjectMilestone(i.issue_id, i.issue_id)
+


### PR DESCRIPTION
The ProjectMilestone field allows us to generate [project boards](https://github.com/orgs/llvm/projects/4/views/20) that slice on project milestone.  

This works by ensuring that all issues tracked by a `category:Project Milestone` issue have the same value for the `ProjectMilestone` field.

While doing this is also detects and warns about issues that are tracked by multiple project milestone issues.