### PR TITLE
[0018] SPIRV resource representation

### DIFF
--- a/proposals/0018-spirv-resource-representation.md
+++ b/proposals/0018-spirv-resource-representation.md
@@ -2,7 +2,7 @@
 
 # HLSL resources in SPIR-V
 
-*   Proposal: [NNNN](NNNN-spirv-resource-representation.md)
+*   Proposal: [0018](0018-spirv-resource-representation.md)
 *   Author(s): [Steven Perron](https://github.com/s-perron)
 *   Status: **Design In Progress**
 
@@ -259,7 +259,7 @@ RWStructuredBuffer<int> a;
 // needs a different counter var.
 RWStructuredBuffer<int> b;
 
-static RWBuffer<int> c; // What type should `c`'s be?
+static RWStructuredBuffer<int> c; // What type should `c`'s be?
 
 void main() {
   c = a; // It must match the type for a.

--- a/proposals/XXXX-spirv-resource-representation.md
+++ b/proposals/XXXX-spirv-resource-representation.md
@@ -144,19 +144,17 @@ target("spirv.Image", ...)
 The details of the `spirv.Image` type depend on the specific declaration. Except
 for the image format, the value for each operand is given in the
 [Mapping Resource Attributes to DXIL and SPIR-V](https://github.com/llvm/wg-hlsl/blob/main/proposals/0015-resource-attributes-in-dxil-and-spirv.md)
-proposal. For all resource types other than `Buffer<T>` and `RWBuffer<T>`, the
-image format will be `Unknown`.
+proposal. For all resource types other than `RWBuffer<T>` and `RWTexture*<T>`,
+the image format will be `Unknown`.
 
-For `Buffer<T>`, if Clang can determine that the `StorageImageReadWithoutFormat`
-capability is available, the image format will be `Unknown`. Similarly, with
-`RWBuffer<T>` and the `StorageImageWriteWithoutFormat` capability. See Table 1
-in the
-[Vulkan Environment for SPIR-V](https://docs.vulkan.org/spec/latest/appendices/spirvenv.html)
-In particular, if the Vulkan version is 1.3 or later, the image format will be
-`Unknown`.
+For `RWBuffer<T>` and `RWTexture*<T>` resource types, if the Vulkan version is
+1.3 or later, the image format will be `Unknown`. This satisfies
+[VUID-RuntimeSpirv-apiVersion-07954](https://docs.vulkan.org/spec/latest/appendices/spirvenv.html#VUID-RuntimeSpirv-apiVersion-07954)
+and
+[VUID-RuntimeSpirv-apiVersion-07955](https://docs.vulkan.org/spec/latest/appendices/spirvenv.html#VUID-RuntimeSpirv-apiVersion-07954).
 
-Otherwise, the image format will be determined by the template type `T`, and
-will match the existing behaviour implemented in DXC.
+Otherwise, the image format for those resource types will be determined by the
+template type `T`, and will match the existing behaviour implemented in DXC.
 
 Note that this creates disconnect with the
 [Universal Validation Rules](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_universal_validation_rules).
@@ -175,18 +173,13 @@ it is used.
 
 The handle for structured buffers will be
 
-| HLSL Resource Type                   | Handle Type                        |
-| ------------------------------------ | ---------------------------------- |
-| StructuredBuffer<T>                  | spv.VulkanBuffer(T, StorageBuffer, |
-:                                      : false, false)                      :
-| RWStructuredBuffer<T>                | spv.VulkanBuffer(T, StorageBuffer, |
-:                                      : true, false)                       :
-| RasterizerOrderedStructuredBuffer<T> | spv.VulkanBuffer(T, StorageBuffer, |
-:                                      : true, true)                        :
-| AppendStructuredBuffer<T>            | spv.VulkanBuffer(T, StorageBuffer, |
-:                                      : true, false)                       :
-| ConsumeStructuredBuffer<T>           | spv.VulkanBuffer(T, StorageBuffer, |
-:                                      : true, false)                       :
+| HLSL Resource Type                   | Handle Type                                      |
+|--------------------------------------|--------------------------------------------------|
+| StructuredBuffer<T>                  | spv.VulkanBuffer(T, StorageBuffer, false, false) |
+| RWStructuredBuffer<T>                | spv.VulkanBuffer(T, StorageBuffer, true, false)  |
+| RasterizerOrderedStructuredBuffer<T> | spv.VulkanBuffer(T, StorageBuffer, true, true)   |
+| AppendStructuredBuffer<T>            | spv.VulkanBuffer(T, StorageBuffer, true, false)  |
+| ConsumeStructuredBuffer<T>           | spv.VulkanBuffer(T, StorageBuffer, true, false)  |
 
 ### Texture buffers
 
@@ -234,14 +227,11 @@ Note that if
 [untyped pointers](https://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_untyped_pointers.html)
 are available, this will map naturally to untyped pointers.
 
-| HLSL Resource Type                 | Handle Type                           |
-| ---------------------------------- | ------------------------------------- |
-| ByteAddressBuffer                  | spv.VulkanBuffer(void, StorageBuffer, |
-:                                    : false, false)                         :
-| RWByteAddressBuffer                | spv.VulkanBuffer(void, StorageBuffer, |
-:                                    : true, false)                          :
-| RasterizerOrderedByteAddressBuffer | spv.VulkanBuffer(void, StorageBuffer, |
-:                                    : true, true)                           :
+| HLSL Resource Type                 | Handle Type                                         |
+|------------------------------------|-----------------------------------------------------|
+| ByteAddressBuffer                  | spv.VulkanBuffer(void, StorageBuffer, false, false) |
+| RWByteAddressBuffer                | spv.VulkanBuffer(void, StorageBuffer, true, false)  |
+| RasterizerOrderedByteAddressBuffer | spv.VulkanBuffer(void, StorageBuffer, true, true)   |
 
 ### Feedback textures
 

--- a/proposals/XXXX-spirv-resource-representation.md
+++ b/proposals/XXXX-spirv-resource-representation.md
@@ -165,18 +165,13 @@ it is used.
 
 The handle for structured buffers will
 
-| HLSL Resource Type                   | Handle Type                         |
-| ------------------------------------ | ----------------------------------- |
-| StructuredBuffer<T>                  | spv.Buffer(T, StorageBuffer, false, |
-:                                      : false)                              :
-| RWStructuredBuffer<T>                | spv.Buffer(T, StorageBuffer, true,  |
-:                                      : false, set, binding)                :
-| RasterizerOrderedStructuredBuffer<T> | spv.Buffer(T, StorageBuffer, true,  |
-:                                      : true, set, binding)                 :
-| AppendStructuredBuffer<T>            | spv.Buffer(T, StorageBuffer, true,  |
-:                                      : false, set, binding)                :
-| ConsumeStructuredBuffer<T>           | spv.Buffer(T, StorageBuffer, true,  |
-:                                      : false, set, binding)                :
+| HLSL Resource Type                   | Handle Type                                             |
+|--------------------------------------|---------------------------------------------------------|
+| StructuredBuffer<T>                  | spv.Buffer(T, StorageBuffer, false, false)              |
+| RWStructuredBuffer<T>                | spv.Buffer(T, StorageBuffer, true, false, set, binding) |
+| RasterizerOrderedStructuredBuffer<T> | spv.Buffer(T, StorageBuffer, true, true, set, binding)  |
+| AppendStructuredBuffer<T>            | spv.Buffer(T, StorageBuffer, true, false, set, binding) |
+| ConsumeStructuredBuffer<T>           | spv.Buffer(T, StorageBuffer, true, false, set, binding) |
 
 The `set` and `binding` will be set following the convention in DXC. The set
 will be the same as the set for the main storage. If the
@@ -230,14 +225,11 @@ Note that if
 [untyped pointers](https://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_untyped_pointers.html)
 are available, this will map naturally to untyped pointers.
 
-| HLSL Resource Type                 | Handle Type                            |
-| ---------------------------------- | -------------------------------------- |
-| ByteAddressBuffer                  | spv.Buffer(void, StorageBuffer, false, |
-:                                    : false)                                 :
-| RWByteAddressBuffer                | spv.Buffer(void, StorageBuffer, true,  |
-:                                    : false)                                 :
-| RasterizerOrderedByteAddressBuffer | spv.Buffer(void, StorageBuffer, true,  |
-:                                    : true)                                  :
+| HLSL Resource Type                 | Handle Type                                   |
+|------------------------------------|-----------------------------------------------|
+| ByteAddressBuffer                  | spv.Buffer(void, StorageBuffer, false, false) |
+| RWByteAddressBuffer                | spv.Buffer(void, StorageBuffer, true,  false) |
+| RasterizerOrderedByteAddressBuffer | spv.Buffer(void, StorageBuffer, true,  true)  |
 
 ### Feedback textures
 

--- a/proposals/XXXX-spirv-resource-representation.md
+++ b/proposals/XXXX-spirv-resource-representation.md
@@ -35,164 +35,209 @@ resource. It will return a target type to represent the handle. Then other
 intrinsics will be used to access the resource using the handle. Previous
 proposals left open what the target types should be for SPIR-V.
 
-The general pattern for the solution will be that `@llvm.spv.handle.fromBinding`
-will return a SPIR-V pointer to a type `T`. The type for `T` will be detailed
-when discussing each HLSL resource type. The SPIR-V backend will create a global
-variable with type `T` if `range_size` is 1, and `T[range_size]` otherwise.
+The type for the handle will depend on the type of resource, and will be
+detailed in the following sections.
 
-The reason we want `@llvm.spv.handle.fromBinding` to return a pointer is to make
-it easier to satisfy the SPIR-V requirements in the
+The following sections will reference table 4 in the
+[shader resrouce interface](https://docs.vulkan.org/spec/latest/chapters/interfaces.html#interfaces-resources)
+for Vulkan.
+
+### SPIR-V target types
+
+The must be appropriate SPIR-V target types to represent the HLSL resources. We
+could try to represent the resources using the exact SPIR-V type that will be.
+The problem is that the HLSL resources does not map too closely with SPIR-V.
+
+Consider `StructuredBuffer`, `RWStructuredBuffer`,
+`RasterizerOrderedStructuredBuffer`, `AppendStructureBuffer`, and
+`ConsumeStructuredBuffer`. These resource types do not map directly to SPIR-V.
+They have multiple implicit features that need to map to different SPIR-V:
+
+1.  They all contains an array of memory that maps to a storage buffer.
+2.  Other than `StructuredBuffer`, they all contains a separate counter variable
+    that is its own storage buffer.
+3.  The references to `RasterizerOrderedStructuredBuffer` are contained in
+    implicit critical regions. In SPIR-V, explicit instructions are used to
+    start and stop the critical region.
+
+This makes it impossible to create a handle type that maps directly to a SPIR-V
+type. To handle this, we will create a target type `spv.Buffer`:
+
+```
+target("spv.Buffer", ElementType, StorageClass, IsWriteable, IsROV)
+target("spv.Buffer", ElementType, StorageClass, IsWriteable, IsROV, CounterSet, CounterBinding)
+```
+
+`ElementType` is the type for the storage buffer array, and `StorageClass` is
+the storage class for the array. `IsWritable` is true of the resource an be
+written to, and `IsROV` is true if it is a rasterizer order view. If the
+resource has an associated counter variable, its set and binding can be provided
+in `CounterSet` and `CounterBinding`.
+
+In the SPIR-V backend, there will be a legalization pass that will lower the
+`spv.Buffer` type to code closer to the SPIR-V to be generated:
+
+1.  Calls to `@llvm.spv.handle.fromBinding` will be replaced by two calls. One
+    that returns a handle to the array, and another that return a handle to the
+    counter, if necessary.
+2.  Calls to `@llvm.spv.resource.getpointer` will have the handle replaced by
+    the handle of the array.
+3.  Calls to `@llvm.spv.resource.updatecounter` will be replaced by a call to
+    `@llvm.spv.resource.getpointer` with the handle of the counter followed by
+    an atomic add.
+4.  If the type of the original handle is rasterizer ordered, all uses of
+    `@llvm.spv.resource.getpointer` will be surrounded by instructions to begin
+    and end the critical region.
+
+A separate legalization pass will then move the critical region markers so that
+they follow the rules required by the SPIR-V specification. This will be the
+same as the
+[`InvocationInterlockPlacementPass`](https://github.com/KhronosGroup/SPIRV-Tools/blob/682bcd51548e670811f1d03511968bb59a1157ce/source/opt/invocation_interlock_placement_pass.h)
+pass in SPIR-V Tools.
+
+The types for the handles will be target types that represent pointers. The
+handle for the array will be
+
+```llvm-ir
+%T = type { ... } ; Fully laid out version of T.
+%T1 = type { [0 x %T] } ; The SPIR-V backend should turn the array into a runtime array.
+target("spirv.Type", target(spirv.Literal, StorageClass), %T1,
+/* OpTypePointer */32)
+```
+
+TODO: I need to check if a call to `int_spv_assign_decoration` can be added that
+will decorate the target type with the block decoration.
+
+The types for the buffers must have an
+[explicit layout](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#ExplicitLayout).
+The layout information will be obtained from the DataLayout class:
+
+1.  Struct offsets will come from `DataLayout::getStructLayout`, which returns
+    the offset for each member.
+2.  The array stride will be the size of the array elements. This assumes that
+    structs have appropriate padding at the end to ensure its size is a multiple
+    of its alignment.
+3.  Matrix stride?
+4.  Row major vs Col major?
+
+It is Clang's responsibility to make sure that the data layout is set correctly,
+and that the structs have the correct explicit padding for this to be correct.
+
+The type of the handle for the counter will be
+
+```llvm-ir
+target("spirv.Type", target(spirv.Literal, /* StorageBuffer */ 12),
+target("spirv.DecoratedType", { i32 }, /* block */ 2),
+/* OpTypePointer */32)
+```
+
+### Textures and typed buffers
+
+All of these resource types are represented using an image type in SPIRV. The
+`Texture*` types are implemented as sampled images. The `RWTexture*` types are
+implemented as storage images. `Buffer` is implemented as a uniform buffer, and
+`RWBuffer` is implemented as a storage buffer.
+
+For these cases the return type from `@llvm.spv.handle.fromBinding` would be the
+image type matching the resource type:
+
+```llvm-ir
+target("spirv.Image", ...)
+```
+
+The details of the `spirv.Image` type depend on the specific declaration, and
+are detailed in the "Mapping Resource Attributes to DXIL and SPIR-V" proposal.
+
+Note that this creates disconnect with the
 [Universal Validation Rules](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_universal_validation_rules).
 Specifically,
 
 > All OpSampledImage instructions, or instructions that load an image or sampler
 > reference, must be in the same block in which their Result <id> are consumed.
 
-It is the responsibility of the intrinsics that use the handles to load the
-images and samplers.
+The image object is conceptually loaded at the location that
+`@llvm.spv.handle.fromBinding` is called. There is nothing forcing this
+intrinsic to be called in the same basic block in which it is used. It is the
+responsibility of the backend to replicate the load in the basic block in which
+it is used.
 
-The following sections will reference table 4 in the
-[shader resrouce interface](https://docs.vulkan.org/spec/latest/chapters/interfaces.html#interfaces-resources)
-for Vulkan.
+### Structured Buffers
 
-### Textures and typed buffers
+The handle for structured buffers will
 
-All of these resource types are represented using an image type in SPIRV. The
-`Texture*` types are implemented as sampled images. the `RWTexture*` types are
-implemented as storage images. `Buffer` is implemented as a uniform buffer, and
-`RWBuffer` is implemented as a storage buffer.
+| HLSL Resource Type                   | Handle Type                         |
+| ------------------------------------ | ----------------------------------- |
+| StructuredBuffer<T>                  | spv.Buffer(T, StorageBuffer, false, |
+:                                      : false)                              :
+| RWStructuredBuffer<T>                | spv.Buffer(T, StorageBuffer, true,  |
+:                                      : false, set, binding)                :
+| RasterizerOrderedStructuredBuffer<T> | spv.Buffer(T, StorageBuffer, true,  |
+:                                      : true, set, binding)                 :
+| AppendStructuredBuffer<T>            | spv.Buffer(T, StorageBuffer, true,  |
+:                                      : false, set, binding)                :
+| ConsumeStructuredBuffer<T>           | spv.Buffer(T, StorageBuffer, true,  |
+:                                      : false, set, binding)                :
 
-For these cases the return type from `@llvm.spv.handle.fromBinding` would be:
+The `set` and `binding` will be set following the convention in DXC. The set
+will be the same as the set for the main storage. If the
+`vk::counter_binding(b)` attribute is attached to the variable, then the binding
+will be `b`. Otherwise, the `binding` will be the binding number of the main
+storage plus 1.
 
-```llvm-ir
-target("spirv.Pointer", 0 /* UniformConstantStorageClass */, target("spirv.Image", ...))
+### Texture buffers
+
+Texture buffers are implemented in SPIR-V as storage buffers. From a SPIR-V
+perspective, this makes it the same as a `StructureBuffer`, and will be
+represented the same way:
+
 ```
-
-The details of the `spirv.Image` type depend on the specific declaration, and
-are detailed in the "Mapping Resource Attributes to DXIL and SPIR-V" proposal.
-
-### Structured buffers and texture buffers
-
-All structured buffers and texture buffers are represented as storge buffers in
-SPIR-V. The Vulkan documentation has two ways to represent a storage buffer. The
-first representation was removed in SPIR-V 1.3 (Vulkan 1.1). We will generate
-only the second representation.
-
-For these cases the return type from `@llvm.spv.handle.fromBinding` for
-`RWStructuredBuffer<T>` would be:
-
-```llvm-ir
-%T = type { ... } ; Fully laid out version of T.
-%T1 = type { [0 x %T] } ; The SPIR-V backend should turn the array into a runtime array.
-target("spirv.Type", target(spirv.Literal, /* StorageBuffer */ 12),
-                     target("spirv.DecoratedType", %T1, /* block */ 2),
-                     /* OpTypePointer */32)
+spv.Buffer(T, StorageBuffer, false, false)
 ```
-
-Note that the llvm-ir does not have to be exactly that, but should be
-equivalent. For example, there does not have to be a identified type for `%T1`.
-
-For `StructuredBuffer<T>`,
-
-```llvm-ir
-%T = type { ... } ; Fully laid out version of T.
-%T1 = type { [0 x %T] } ; The SPIR-V backend should turn the array into a runtime array.
-target("spirv.Type", target(spirv.Literal, /* StorageBuffer */ 12),
-                     target("spirv.DecoratedType",
-                            target("spirv.DecoratedType", %T1, /* block */ 2),
-                            /* NonWriteable */ 24),
-                     /* OpTypePointer */32)
-```
-
-This is the same as `RWStructuredBuffer` except that it has the NonWritable
-decoration.
-
-The specific layout for `T` is out of scope for this proposal, and will be part
-of another proposal.
 
 ### Constant buffers
 
-Constant buffers are implemented as uniform buffers. They will have the exact
-same representation as a `StructuredBuffer` except that the storage class will
-be `Uniform` instead of `StorageBuffer`. The layout will potentially be
-different.
+In SPIR-V, constant buffers are implemented as uniform buffers. The only
+difference between a uniform buffer and storage buffer is the storage class.
+Uniform buffers use the `Uniform` storage class. The handle type will be:
+
+```
+spv.Buffer(T, Uniform, false, false)
+```
 
 ### Samplers
 
-The return type from `@llvm.spv.handle.fromBinding` for a sampler will be:
+The type of the handle for a sampler will be:
 
 ```llvm-ir
-target("spirv.Type", target(spirv.Literal, /* UniformConstantStorageClass */ 0),
-                     target("spirv.Sampler"),
-                     /* OpTypePointer */32)
+target("spirv.Sampler")
 ```
 
 This is the same for a `SamplerState` and `SamplerComparisonState`.
 
 ### Byte address buffers
 
-If
+DXC represents byte address buffers as a storage buffer of 32-bit integers. The
+problem with this is that loads and store require lots of data manipulation to
+correctly handle the data. It also means we cannot do atomic operations unless
+they are 32-bit operations.
+
+Because of this limitation, we do not want Clang to enforce a particular
+representation. Instead, we can represent the buffer as a buffer with a `void`
+type. The backend indicates to the backend it can choose the representation, but
+it is responsible for updating accessed to match the representation it chooses.
+
+Note that if
 [untyped pointers](https://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_untyped_pointers.html)
-are available, we will want to use the untyped pointers. However, if they are
-not available, we will need to represent it as an array of integers, as is done
-in DXC.
+are available, this will map naturally to untyped pointers.
 
-TODO: I'm thinking it is the responsibility of SPIRVTargetInfo to make this
-decision.
-
-If
-[untyped pointers](https://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_untyped_pointers.html)
-are available, then the return type from `@llvm.spv.handle.fromBinding` for a
-`RWByteAddressBuffer` would be:
-
-```llvm-ir
-target("spirv.Type", target(spirv.Literal, /* StorageBuffer */ 12),
-                     /* OpTypeUntypedPointerKHR */ 4417)
-```
-
-This assumes that knowledge of untyped pointers is added to the SPIR-V backend.
-If it is not added, we will have to explicitly attached the capability and
-extension to the type.
-
-If untyped pointers are not available, then the return type from
-`@llvm.spv.handle.fromBinding` would be:
-
-```llvm-ir
-target("spirv.Type", target(spirv.Literal, /* StorageBuffer */ 12),
-                     target("spirv.DecoratedType", { [0 x i32] }, /* block */ 2),
-                     /* OpTypePointer */32)
-```
-
-It would be the same for `ByteAddressBuffer` except the `NonWriteable`
-decoration is will be added.
-
-The intrinsics that use the ByteAddressBuffers will not change depending on the
-type used. The SPIR-V backend should recognize the type and implement the
-operation accordingly.
-
-### Rasterizer Order Views
-
-TODO: This needs to be redone. We might need to add the attribute to the
-fromBinding call site.
-
-If a resource is a rasterizer order view it will generate the exact same code as
-its regular version except
-
-1.  All uses of the resource will have a call site attribute indicating that
-    this call must be part of the fragment shader's critical section. This is a
-    new target attribute which will be call `spirv.InterlockedCritical`.
-2.  The entry points (that reference directly or indirectly?) the ROVs will have
-    an attribute `spirv.InterlockMode` which could have the value
-    `SampleOrdered`, `SampleUnordered`, `PixelOrdered`, `PixelUnordered`,
-    `ShadingRateOrdered`, or `ShadingRateUnordered`.
-
-A pass similar to the `InvocationInterlockPlacementPass` pass in SPIR-V Tools
-will be run in the SPIR-V backend to add instructions to begin and end the
-critical section. This pass will be run after structurizing the llvm-ir, and
-before ISel.
-
-The SPIR-V backend will add the appropriate interlock execution mode to the
-module based on the attribute on the entry point.
+| HLSL Resource Type                 | Handle Type                            |
+| ---------------------------------- | -------------------------------------- |
+| ByteAddressBuffer                  | spv.Buffer(void, StorageBuffer, false, |
+:                                    : false)                                 :
+| RWByteAddressBuffer                | spv.Buffer(void, StorageBuffer, true,  |
+:                                    : false)                                 :
+| RasterizerOrderedByteAddressBuffer | spv.Buffer(void, StorageBuffer, true,  |
+:                                    : true)                                  :
 
 ### Feedback textures
 
@@ -200,39 +245,26 @@ These resources do not have a straight-forward implementation in SPIR-V, and
 they were not implemented in DXC. We will issue an error if these resource are
 used when targeting SPIR-V.
 
-## Detailed design
-
-*The detailed design is not required until the feature is under review.*
-
-This section should grow into a full specification that will provide enough
-information for someone who isn't the proposal author to implement the feature.
-It should also serve as the basis for documentation for the feature. Each
-feature will need different levels of detail here, but some common things to
-think through are:
-
-*   Is there any potential for changed behavior?
-*   Will this expose new interfaces that will have support burden?
-*   How will this proposal be tested?
-*   Does this require additional hardware/software/human resources?
-*   What documentation should be updated or authored?
-
 ## Alternatives considered (Optional)
 
-### Returning an image type in `@llvm.spv.handle.fromBinding`
+### Returning pointers as the handle
 
-We considered implementing returning the `target("spirv.Image", ...)` type from
-`@llvm.spv.handle.fromBinding` instead of returning a pointer to the type. This
-caused problems because the uses of the image have to be in the same basic
-block, and, in general, the uses of the handle are not in the same basic block
-as the call to `@llvm.spv.handle.fromBinding`.
+We considered making all handles return by `@llvm.spv.handle.fromBinding` to be
+pointers to some type. For textures, it would return a pointer to the image
+type.
 
-To fix this, we would have to add a pass in the backend to fix up the problem by
-replicating code, but this seems less desirable when we can generate the code
-correctly.
+This would have been nice because load of the image object would no longer be in
+`@llvm.spv.handle.fromBinding` and would be in the intrinsic that uses the
+handle. That would automatically make it in the same basic block as it use.
 
-It also makes the implementation of `@llvm.spv.handle.fromBinding` more
-complicated because it will have to be treated differently than structured
-buffers.
+The problem is that this does not work well for structured buffers, because, as
+far as HLSL is concerned, the handle for a structured buffer references two
+resources as detailed above. There is no way to represent this properly.
+
+Less important, but still worth mentioning, is that in SPIR-V, the image object
+is the handle to the image. We chose the design the was the better match
+conceptually. Replicating the load of the image object is not a difficult
+problem to solve.
 
 ## Acknowledgments (Optional)
 

--- a/proposals/XXXX-spirv-resource-representation.md
+++ b/proposals/XXXX-spirv-resource-representation.md
@@ -1,0 +1,225 @@
+<!-- {% raw %} -->
+
+# HLSL resources in SPIR-V
+
+*   Proposal: [NNNN](NNNN-spirv-resource-representation.md)
+*   Author(s): [Steven Perron](https://github.com/s-perron)
+*   Status: **Design In Progress**
+
+*During the review process, add the following fields as needed:*
+
+*   PRs: [#114273](https://github.com/llvm/llvm-project/pull/114273),
+    [#111052](https://github.com/llvm/llvm-project/pull/111052),
+    [#111564](https://github.com/llvm/llvm-project/pull/111564),
+    [#115178](https://github.com/llvm/llvm-project/pull/115178)
+
+## Introduction
+
+There is a need to represent the HLSL resources in llvm-ir in a way that the
+SPIR-V backend is able to create the correct code. We have already done some
+implementation work for `Buffer` and `RWBuffer`. This was done as a
+proof-of-concept, and now we needed to determine how the other resource types
+will be represented.
+
+## Motivation
+
+The HLSL resources are fundamental to HLSL, and they are required in a Vulkan
+implementation.
+
+## Proposed solution
+
+We want to match the general solution proposed in
+[0006-resource-representations.md](0006-resource-representations.md). The
+`@llvm.spv.handle.fromBinding` intrinsic will be used to get a handle to the
+resource. It will return a target type to represent the handle. Then other
+intrinsics will be used to access the resource using the handle. Previous
+proposals left open what the target types should be for SPIR-V.
+
+The general pattern for the solution will be that `@llvm.spv.handle.fromBinding`
+will return a SPIR-V pointer to a type `T`. The type for `T` will be detailed
+when discusses each HLSL resource type. The SPIR-V backend will create a global
+variable with type `T` if `range_size` is 1, and `T[range_size]` otherwise.
+
+The reason we want `@llvm.spv.handle.fromBinding` to return a pointer is to make
+it easier to satisfy the SPIR-V requirements in the
+[Universal Validation Rules](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_universal_validation_rules).
+Specifically,
+
+> All OpSampledImage instructions, or instructions that load an image or sampler
+> reference, must be in the same block in which their Result <id> are consumed.
+
+It is the responsibility of the intrinsics that use the handles to load the
+images and samplers.
+
+The following sections will reference table 4 in the
+[shader resrouce interface](https://docs.vulkan.org/spec/latest/chapters/interfaces.html#interfaces-resources)
+for Vulkan.
+
+### Textures and typed buffers
+
+All of these resource types are represented using an image type in SPIRV. The
+`Texture*` types are implemented as sampled images. the `RWTexture*` types are
+implemented as storage images. `Buffer` is implemented as a uniform buffer, and
+`RWBuffer` is implemented as a storage buffer.
+
+For these cases the return type from `@llvm.spv.handle.fromBinding` would be:
+
+```llvm-ir
+target("spirv.Pointer", 0 /* UniformConstantStorageClass */, target("spirv.Image", ...))
+```
+
+The details of the `spirv.Image` type depend on the specific declaration.
+
+TODO: We need to determine the image format.
+
+### Structured buffers and texture buffers
+
+All structured buffers and texture buffers are represented as storge buffers in
+SPIR-V. The Vulkan documentation has two ways to represent a storage buffer. The
+first representation was removed in SPIR-V 1.3 (Vulkan 1.1). We will generate
+only the second representation.
+
+For these cases the return type from `@llvm.spv.handle.fromBinding` for
+`RWStructuredBuffer<T>` would be:
+
+```llvm-ir
+target("spirv.Pointer", 12 /* StorageBuffer */, T')
+```
+
+Where `T' = struct { T t[]; }`.
+
+For `StructuredBuffer<T>`,
+
+```llvm-ir
+target("spirv.Pointer", 12 /* StorageBuffer */, const T')
+```
+
+TODO: We need to determine how the Block decoration will be added. The current
+idea will have clang describe the type in detail, which means that clang needs a
+way to say that the type `T'` requires the decoration. There is a
+`spirv.Decoration` metadata, but that works on global variable only at this
+time. We could have the target spirv type access the metadata node as an
+operand. This interacts with the implementation of `vk::ext_decorate`, which
+will have to be able to apply decoration to members of types.
+
+TODO: We need to determine what the layout of the struct should be. Will we
+support multiple layout as we do in DXC? This could be communicated to the back
+end by adding the decorations to the type in the same way as the previous todo.
+
+Note: We are in the middle of implementing `vk::SpirvType` in clang. That should
+add a way to implement the target types without adding a specific
+`spirv.Pointer` target type.
+
+### Constant buffers
+
+Constant buffers are implemented as uniform buffers. They will have the exact
+same representation as a structured buffer except that the storage class will be
+`Uniform` instead of `UniformConstant`.
+
+### Samplers
+
+For these cases the return type from `@llvm.spv.handle.fromBinding` would be:
+
+```llvm-ir
+target("spirv.Pointer", 0 /* UniformConstantStorageClass */, target("spirv.Sampler"))
+```
+
+This is the same for a `SamplerState` and `SamplerComparisonState`.
+
+### Byte address buffers
+
+If
+[untyped pointers](https://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_untyped_pointers.html)
+are available, we will want to use the untyped pointers. However, if they are
+not available, we will need to represent it as an array of integers, as is done
+in DXC.
+
+TODO: I'm thinking it is the responsibility of SPIRVTargetInfo to make this
+decision.
+
+If
+[untyped pointers](https://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_untyped_pointers.html)
+are available, then the return type from `@llvm.spv.handle.fromBinding` would
+be:
+
+```llvm-ir
+target("spirv.UntypedPointer", 12 /* StorageBuffer */)
+```
+
+If untyped pointers are not available, then the return type from
+`@llvm.spv.handle.fromBinding` would be:
+
+```llvm-ir
+target("spirv.Pointer", 12 /* StorageBuffer */, { uint32_t[] })
+```
+
+TODO: Add the `block` decoration.
+
+The intrinsics that use the ByteAddressBuffers will not change depending on the
+type used. The SPIR-V backend should recognize the type and implement
+accordingly.
+
+### Rasterizer Order Views
+
+If a resource is a rasterizer order view it will generate the exact same code as
+its regular version except
+
+1.  All uses of the resource will have a call site attribute indicating that
+    this call must be part of the fragment shader's critical section. This is a
+    new target attribute which will be call `spirv.InterlockedCritical`.
+2.  The entry points (that reference directly or indirectly?) the ROVs will have
+    an attribute `spirv.InterlockMode` which could have the value
+    `SampleOrdered`, `SampleUnordered`, `PixelOrdered`, `PixelUnordered`,
+    `ShadingRateOrdered`, or `ShadingRateUnordered`.
+
+A pass similar to the `InvocationInterlockPlacementPass` pass in SPIR-V Tools
+will be run in the SPIR-V backend to add instructions to begin and end the
+critical section. This pass will be run after structurizing the llvm-ir, and
+before ISel.
+
+The SPIR-V backend will add the appropriate interlock execution mode to the
+module based on the attribute on the entry point.
+
+### Feedback textures
+
+These resources do not have a straight-forward implementation in SPIR-V, and
+they were not implemented in DXC. We will issue an error if these resource are
+used when targeting SPIR-V.
+
+## Detailed design
+
+*The detailed design is not required until the feature is under review.*
+
+This section should grow into a full specification that will provide enough
+information for someone who isn't the proposal author to implement the feature.
+It should also serve as the basis for documentation for the feature. Each
+feature will need different levels of detail here, but some common things to
+think through are:
+
+*   Is there any potential for changed behavior?
+*   Will this expose new interfaces that will have support burden?
+*   How will this proposal be tested?
+*   Does this require additional hardware/software/human resources?
+*   What documentation should be updated or authored?
+
+## Alternatives considered (Optional)
+
+### Returning an image type in `@llvm.spv.handle.fromBinding`
+
+We considered implementing returning the `target("spirv.Image", ...)` type from
+`@llvm.spv.handle.fromBinding` instead of returning a pointer to the type. This
+caused problems because the uses of the image have to be in the same basic
+block, and, in general, the uses of the handle are not in the same basic block
+as the call to `@llvm.spv.handle.fromBinding`.
+
+To fix this, we would have to add a pass in the backend to fix up the problem by
+replicating code, but this seems less desirable when we can generate the code
+correctly.
+
+It also makes the implementation of `@llvm.spv.handle.fromBinding` more
+complicated because it will have to be treated differently than structured
+buffers.
+
+## Acknowledgments (Optional)
+
+<!-- {% endraw %} -->

--- a/proposals/XXXX-spirv-resource-representation.md
+++ b/proposals/XXXX-spirv-resource-representation.md
@@ -273,4 +273,11 @@ void main() {
   c = b; // It must also match the type for b.
 ```
 
+2. Do we need `vk::image_format` for Vulkan 1.3 and later?
+
+We need to determine whether we can deprecate the use of `vk::image_format` for
+Vulkan 1.3 and later. We could potentially use unknown for all resource types. 
+We need to assess if there is any advantage to specifying a particular format. 
+If no advantage exists, then we should not attempt to support specific formats.
+
 <!-- {% endraw %} -->

--- a/proposals/XXXX-spirv-resource-representation.md
+++ b/proposals/XXXX-spirv-resource-representation.md
@@ -39,42 +39,43 @@ The type for the handle will depend on the type of resource, and will be
 detailed in the following sections.
 
 The following sections will reference table 4 in the
-[shader resrouce interface](https://docs.vulkan.org/spec/latest/chapters/interfaces.html#interfaces-resources)
+[shader resource interface](https://docs.vulkan.org/spec/latest/chapters/interfaces.html#interfaces-resources)
 for Vulkan.
 
 ### SPIR-V target types
 
-The must be appropriate SPIR-V target types to represent the HLSL resources. We
-could try to represent the resources using the exact SPIR-V type that will be.
-The problem is that the HLSL resources does not map too closely with SPIR-V.
+There must be appropriate SPIR-V target types to represent the HLSL resources.
+We could try to represent the resources using the exact SPIR-V type that will be
+needed. The problem is that the HLSL resources does not map too closely with
+SPIR-V.
 
 Consider `StructuredBuffer`, `RWStructuredBuffer`,
 `RasterizerOrderedStructuredBuffer`, `AppendStructureBuffer`, and
 `ConsumeStructuredBuffer`. These resource types do not map directly to SPIR-V.
 They have multiple implicit features that need to map to different SPIR-V:
 
-1.  They all contains an array of memory that maps to a storage buffer.
-2.  Other than `StructuredBuffer`, they all contains a separate counter variable
+1.  They all contain an array of memory that maps to a storage buffer.
+2.  Other than `StructuredBuffer`, they all contain a separate counter variable
     that is its own storage buffer.
 3.  The references to `RasterizerOrderedStructuredBuffer` are contained in
     implicit critical regions. In SPIR-V, explicit instructions are used to
     start and stop the critical region.
 
 This makes it impossible to create a handle type that maps directly to a SPIR-V
-type. To handle this, we will create a target type `spv.VulkanBuffer`:
+type. To handle this, we will create a target type `spirv.VulkanBuffer`:
 
 ```
-target("spv.VulkanBuffer", ElementType, StorageClass, IsWriteable, IsROV)
+target("spirv.VulkanBuffer", ElementType, StorageClass, IsWriteable, IsROV)
 ```
 
 `ElementType` is the type for the storage buffer array, and `StorageClass` is
-the storage class for the array. `IsWritable` is true of the resource an be
+the storage class for the array. `IsWriteable` is true if the resource can be
 written to, and `IsROV` is true if it is a rasterizer order view. If the
 resource has an associated counter variable, its set and binding can be provided
 in `CounterSet` and `CounterBinding`.
 
 In the SPIR-V backend, there will be a legalization pass that will lower the
-`spv.VulkanBuffer` type to code closer to the SPIR-V to be generated:
+`spirv.VulkanBuffer` type to code closer to the SPIR-V to be generated:
 
 1.  Calls to `@llvm.spv.handle.fromBinding` will be replaced by two calls. One
     that returns a handle to the array, and another that return a handle to the
@@ -94,16 +95,6 @@ same as the
 [`InvocationInterlockPlacementPass`](https://github.com/KhronosGroup/SPIRV-Tools/blob/682bcd51548e670811f1d03511968bb59a1157ce/source/opt/invocation_interlock_placement_pass.h)
 pass in SPIR-V Tools.
 
-The types for the handles will be target types that represent pointers. The
-handle for the array will be
-
-```llvm-ir
-%T = type { ... } ; Fully laid out version of T.
-%T1 = type { [0 x %T] } ; The SPIR-V backend should turn the array into a runtime array.
-target("spirv.Type", target(spirv.Literal, StorageClass), %T1,
-/* OpTypePointer */32)
-```
-
 The types for the buffers must have an
 [explicit layout](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#ExplicitLayout).
 The layout information will be obtained from the DataLayout class:
@@ -118,14 +109,6 @@ The layout information will be obtained from the DataLayout class:
 
 It is Clang's responsibility to make sure that the data layout is set correctly,
 and that the structs have the correct explicit padding for this to be correct.
-
-The type of the handle for the counter will be
-
-```llvm-ir
-target("spirv.Type", target(spirv.Literal, /* StorageBuffer */ 12),
-target("spirv.DecoratedType", { i32 }, /* block */ 2),
-/* OpTypePointer */32)
-```
 
 ### Textures and typed buffers
 
@@ -173,13 +156,13 @@ it is used.
 
 The handle for structured buffers will be
 
-| HLSL Resource Type                   | Handle Type                                      |
-|--------------------------------------|--------------------------------------------------|
-| StructuredBuffer<T>                  | spv.VulkanBuffer(T, StorageBuffer, false, false) |
-| RWStructuredBuffer<T>                | spv.VulkanBuffer(T, StorageBuffer, true, false)  |
-| RasterizerOrderedStructuredBuffer<T> | spv.VulkanBuffer(T, StorageBuffer, true, true)   |
-| AppendStructuredBuffer<T>            | spv.VulkanBuffer(T, StorageBuffer, true, false)  |
-| ConsumeStructuredBuffer<T>           | spv.VulkanBuffer(T, StorageBuffer, true, false)  |
+| HLSL Resource Type                   | Handle Type                                        |
+|--------------------------------------|----------------------------------------------------|
+| StructuredBuffer<T>                  | spirv.VulkanBuffer(T, StorageBuffer, false, false) |
+| RWStructuredBuffer<T>                | spirv.VulkanBuffer(T, StorageBuffer, true, false)  |
+| RasterizerOrderedStructuredBuffer<T> | spirv.VulkanBuffer(T, StorageBuffer, true, true)   |
+| AppendStructuredBuffer<T>            | spirv.VulkanBuffer(T, StorageBuffer, true, false)  |
+| ConsumeStructuredBuffer<T>           | spirv.VulkanBuffer(T, StorageBuffer, true, false)  |
 
 ### Texture buffers
 
@@ -188,7 +171,7 @@ perspective, this makes it the same as a `StructureBuffer`, and will be
 represented the same way:
 
 ```
-spv.VulkanBuffer(T, StorageBuffer, false, false)
+spirv.VulkanBuffer(T, StorageBuffer, false, false)
 ```
 
 ### Constant buffers
@@ -198,7 +181,7 @@ difference between a uniform buffer and storage buffer is the storage class.
 Uniform buffers use the `Uniform` storage class. The handle type will be:
 
 ```
-spv.VulkanBuffer(T, Uniform, false, false)
+spirv.VulkanBuffer(T, Uniform, false, false)
 ```
 
 ### Samplers
@@ -227,11 +210,11 @@ Note that if
 [untyped pointers](https://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_untyped_pointers.html)
 are available, this will map naturally to untyped pointers.
 
-| HLSL Resource Type                 | Handle Type                                         |
-|------------------------------------|-----------------------------------------------------|
-| ByteAddressBuffer                  | spv.VulkanBuffer(void, StorageBuffer, false, false) |
-| RWByteAddressBuffer                | spv.VulkanBuffer(void, StorageBuffer, true, false)  |
-| RasterizerOrderedByteAddressBuffer | spv.VulkanBuffer(void, StorageBuffer, true, true)   |
+| HLSL Resource Type                 | Handle Type                                           |
+|------------------------------------|-------------------------------------------------------|
+| ByteAddressBuffer                  | spirv.VulkanBuffer(void, StorageBuffer, false, false) |
+| RWByteAddressBuffer                | spirv.VulkanBuffer(void, StorageBuffer, true, false)  |
+| RasterizerOrderedByteAddressBuffer | spirv.VulkanBuffer(void, StorageBuffer, true, true)   |
 
 ### Feedback textures
 
@@ -264,8 +247,30 @@ problem to solve.
 
 1.  How will the binding for the counter resource be represented?
 
+The design for the counter variable associated with structured buffer types is
+not complete. However, there is one important restriction the Clang codegen does
+not diverge too much from DXIL:
+
+The storage for the storage buffer and the counter variable must be access
+through the same handle. The intrinsics that use it will determine which
+resource is being accessed.
+
 They will have to somehow be added to the `resource.gethandlefrombinding`. They
 cannot be added to the target type. If they were, the types for the resource
-aliases would not match, causing problem in codegen.
+aliases would not match, causing problem in codegen. For example:
+
+```c++
+RWStructuredBuffer<int> a;
+
+// The type for `b` handle will be different from `a`'s handle, because it
+// needs a different counter var.
+RWStructuredBuffer<int> b;
+
+static RWBuffer<int> c; // What type should `c`'s be?
+
+void main() {
+  c = a; // It must match the type for a.
+  c = b; // It must also match the type for b.
+```
 
 <!-- {% endraw %} -->


### PR DESCRIPTION
Adds a proposal for how HLSL resources will be represented in llvm-ir
when targeting SPIR-V.
