### PR TITLE
[0002] RootSignatures - NFC Formatting Grammar to EBNF

### DIFF
--- a/proposals/0002-root-signature-in-clang.md
+++ b/proposals/0002-root-signature-in-clang.md
@@ -155,9 +155,8 @@ to ensure that our solution doesn't unnecessarily tie the non-HLSL parts to it.
 ### Root Signature Grammar
 
 The root signature DSL is defined using a slightly modified version of Extended
-Backus-Naur form. We define the additional symbol `:` to denote a
-comma-seperated list of components in any order:  `A : B = (A ',' B | B ',' A)`.
-Additionally, all keywords and enums are case-insensitive.
+Backus-Naur form. Where we assume there is arbitrary whitespace between any
+subsequent tokens. Additionally, all keywords and enums are case-insensitive.
 
 ```
     RootSignature = [ RootElement { ',' RootElement } ];
@@ -182,10 +181,11 @@ Additionally, all keywords and enums are case-insensitive.
               'SAMPLER_HEAP_DIRECTLY_INDEXED';
 
     RootConstants = 'RootConstants' '('
-      ( 'num32BitConstants' '=' POS_INT ) : bReg
-      [ : ( 'space' '=' POS_INT ) ]
-      [ : ( 'visibility' '=' SHADER_VISIBILITY ) ]
-    ')';
+      ( 'num32BitConstants' '=' POS_INT ) ',' bReg
+      { ',' RootConstantArgs } ')';
+
+    RootConstantArgs =
+      ( 'space' '=' POS_INT ) | ( 'visibility' '=' SHADER_VISIBILITY );
 
     POS_INT = [ + ] DIGITS;
 
@@ -193,16 +193,16 @@ Additionally, all keywords and enums are case-insensitive.
                             'DATA_STATIC_WHILE_SET_AT_EXECUTE' |
                             'DATA_VOLATILE';
 
-    RootCBV = 'CBV' '(' bReg RootParams ')';
+    RootCBV = 'CBV' '(' bReg { ',' RootParamArgs } ')';
 
-    RootSRV = 'SRV' '(' tReg RootParams ')';
+    RootSRV = 'SRV' '(' tReg { ',' RootParamArgs } ')';
 
-    RootUAV = 'UAV' '(' uReg RootParams ')';
+    RootUAV = 'UAV' '(' uReg { ',' RootParamArgs } ')';
 
-    RootParams =
-      [ : ( 'space' '=' POS_INT ) ]
-      [ : ( 'visibility' '=' SHADER_VISIBILITY ) ]
-      [ : ( 'flags' '=' ROOT_DESCRIPTOR_FLAGS ) ];
+    RootParamArgs =
+      ( 'space' '=' POS_INT ) |
+      ( 'visibility' '=' SHADER_VISIBILITY ) |
+      ( 'flags' '=' ROOT_DESCRIPTOR_FLAGS );
 
     DescriptorTable = 'DescriptorTable' '('
       [ DTClause { : DTClause } ] [ : ( 'visibility' '=' SHADER_VISIBILITY ) ]
@@ -224,13 +224,13 @@ Additionally, all keywords and enums are case-insensitive.
 
     UAV = 'UAV' '(' uReg ClauseArgs ')';
 
-    Sampler = 'Sampler' '(' sReg ClauseArgs ')';
+    Sampler = 'Sampler' '(' sReg { ',' ClauseArgs } ')';
 
     ClauseArgs =
-      [ : ( 'numDescriptors' '=' NUM_DESCRIPTORS_UNBOUNDED ) ]
-      [ : ( 'space' '=' POS_INT ) ]
-      [ : ( 'offset' '=' DESCRIPTOR_RANGE_OFFSET ) ]
-      [ : ( 'flags' '=' DESCRIPTOR_RANGE_FLAGS ) ];
+      ( 'numDescriptors' '=' NUM_DESCRIPTORS_UNBOUNDED ) |
+      ( 'space' '=' POS_INT ) |
+      ( 'offset' '=' DESCRIPTOR_RANGE_OFFSET ) |
+      ( 'flags' '=' DESCRIPTOR_RANGE_FLAGS );
 
     SHADER_VISIBILITY = 'SHADER_VISIBILITY_ALL' |
                         'SHADER_VISIBILITY_VERTEX' |
@@ -245,20 +245,21 @@ Additionally, all keywords and enums are case-insensitive.
 
     DESCRIPTOR_RANGE_OFFSET = 'DESCRIPTOR_RANGE_OFFSET_APPEND' | POS_INT;
 
-    StaticSampler = 'StaticSampler' '(' sReg
-      [ : ( 'filter' '=' FILTER ) ]
-      [ : ( 'addressU' '=' TEXTURE_ADDRESS ) ]
-      [ : ( 'addressV' '=' TEXTURE_ADDRESS ) ]
-      [ : ( 'addressW' '=' TEXTURE_ADDRESS ) ]
-      [ : ( 'mipLODBias' '=' NUMBER ) ]
-      [ : ( 'maxAnisotropy' '=' NUMBER ) ]
-      [ : ( 'comparisonFunc' '=' COMPARISON_FUNC ) ]
-      [ : ( 'borderColor' '=' STATIC_BORDER_COLOR ) ]
-      [ : ( 'minLOD' '=' NUMBER ) ]
-      [ : ( 'maxLOD' '=' NUMBER ) ]
-      [ : ( 'space' '=' POS_INT ) ]
-      [ : ( 'visibility' '=' SHADER_VISIBILITY ) ]
-    ')';
+    StaticSampler = 'StaticSampler' '(' sReg { ',' SamplerArgs }')';
+
+    SamplerArgs =
+      ( 'filter' '=' FILTER ) |
+      ( 'addressU' '=' TEXTURE_ADDRESS ) |
+      ( 'addressV' '=' TEXTURE_ADDRESS ) |
+      ( 'addressW' '=' TEXTURE_ADDRESS ) |
+      ( 'mipLODBias' '=' NUMBER ) |
+      ( 'maxAnisotropy' '=' NUMBER ) |
+      ( 'comparisonFunc' '=' COMPARISON_FUNC ) |
+      ( 'borderColor' '=' STATIC_BORDER_COLOR ) |
+      ( 'minLOD' '=' NUMBER ) |
+      ( 'maxLOD' '=' NUMBER ) |
+      ( 'space' '=' POS_INT ) |
+      ( 'visibility' '=' SHADER_VISIBILITY );
 
     bReg = 'b' DIGITS;
 

--- a/proposals/0002-root-signature-in-clang.md
+++ b/proposals/0002-root-signature-in-clang.md
@@ -162,24 +162,24 @@ Additionally, all keywords and enums are case-insensitive.
 ```
     RootSignature = [ RootElement { ',' RootElement } ];
 
-    RootElement : RootFlags | RootConstants | RootCBV | RootSRV | RootUAV |
-                  DescriptorTable | StaticSampler
+    RootElement = RootFlags | RootConstants | RootCBV | RootSRV | RootUAV |
+                  DescriptorTable | StaticSampler;
 
     RootFlags = 'RootFlags' '(' [ RootFlag { '|' RootFlag } ] ')';
 
-    RootFlag : 0 |
-               'ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT' |
-               'DENY_VERTEX_SHADER_ROOT_ACCESS' |
-               'DENY_HULL_SHADER_ROOT_ACCESS' |
-               'DENY_DOMAIN_SHADER_ROOT_ACCESS' |
-               'DENY_GEOMETRY_SHADER_ROOT_ACCESS' |
-               'DENY_PIXEL_SHADER_ROOT_ACCESS' |
-               'DENY_AMPLIFICATION_SHADER_ROOT_ACCESS' |
-               'DENY_MESH_SHADER_ROOT_ACCESS' |
-               'ALLOW_STREAM_OUTPUT' |
-               'LOCAL_ROOT_SIGNATURE' |
-               'CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED' |
-               'SAMPLER_HEAP_DIRECTLY_INDEXED'
+    RootFlag = 0 |
+              'ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT' |
+              'DENY_VERTEX_SHADER_ROOT_ACCESS' |
+              'DENY_HULL_SHADER_ROOT_ACCESS' |
+              'DENY_DOMAIN_SHADER_ROOT_ACCESS' |
+              'DENY_GEOMETRY_SHADER_ROOT_ACCESS' |
+              'DENY_PIXEL_SHADER_ROOT_ACCESS' |
+              'DENY_AMPLIFICATION_SHADER_ROOT_ACCESS' |
+              'DENY_MESH_SHADER_ROOT_ACCESS' |
+              'ALLOW_STREAM_OUTPUT' |
+              'LOCAL_ROOT_SIGNATURE' |
+              'CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED' |
+              'SAMPLER_HEAP_DIRECTLY_INDEXED';
 
     RootConstants = 'RootConstants' '('
       ( 'num32BitConstants' '=' POS_INT ) : bReg
@@ -187,11 +187,12 @@ Additionally, all keywords and enums are case-insensitive.
       [ : ( 'visibility' '=' SHADER_VISIBILITY ) ]
     ')';
 
-    POS_INT = [ + ] DIGITS
+    POS_INT = [ + ] DIGITS;
 
-    ROOT_DESCRIPTOR_FLAGS : 0 | 'DATA_STATIC' |
+    ROOT_DESCRIPTOR_FLAGS = 0 | 'DATA_STATIC' |
                             'DATA_STATIC_WHILE_SET_AT_EXECUTE' |
-                            'DATA_VOLATILE'
+                            'DATA_VOLATILE';
+
     RootCBV = 'CBV' '(' bReg RootParams ')';
 
     RootSRV = 'SRV' '(' tReg RootParams ')';
@@ -212,12 +213,10 @@ Additionally, all keywords and enums are case-insensitive.
     DESCRIPTOR_RANGE_FLAGS =
       [ DESCRIPTOR_RANGE_FLAG { '|' DESCRIPTOR_RANGE_FLAG } ];
 
-    DESCRIPTOR_RANGE_FLAG : 0 |
-        'DESCRIPTORS_VOLATILE' |
-        'DATA_VOLATILE' |
-        'DATA_STATIC' |
-        'DATA_STATIC_WHILE_SET_AT_EXECUTE' |
-        'DESCRIPTORS_STATIC_KEEPING_BUFFER_BOUNDS_CHECKS'
+    DESCRIPTOR_RANGE_FLAG = 0 | 'DESCRIPTORS_VOLATILE' |
+                            'DATA_VOLATILE' | 'DATA_STATIC' |
+                            'DATA_STATIC_WHILE_SET_AT_EXECUTE' |
+                            'DESCRIPTORS_STATIC_KEEPING_BUFFER_BOUNDS_CHECKS';
 
     CBV = 'CBV' '(' bReg ClauseArgs ')';
 
@@ -233,17 +232,18 @@ Additionally, all keywords and enums are case-insensitive.
       [ : ( 'offset' '=' DESCRIPTOR_RANGE_OFFSET ) ]
       [ : ( 'flags' '=' DESCRIPTOR_RANGE_FLAGS ) ];
 
-    SHADER_VISIBILITY : 'SHADER_VISIBILITY_ALL' | 'SHADER_VISIBILITY_VERTEX' |
+    SHADER_VISIBILITY = 'SHADER_VISIBILITY_ALL' |
+                        'SHADER_VISIBILITY_VERTEX' |
                         'SHADER_VISIBILITY_HULL' |
                         'SHADER_VISIBILITY_DOMAIN' |
                         'SHADER_VISIBILITY_GEOMETRY' |
                         'SHADER_VISIBILITY_PIXEL' |
                         'SHADER_VISIBILITY_AMPLIFICATION' |
-                        'SHADER_VISIBILITY_MESH'
+                        'SHADER_VISIBILITY_MESH';
 
-    DESCRIPTOR_RANGE_OFFSET : 'unbounded' | POS_INT
+    DESCRIPTOR_RANGE_OFFSET = 'unbounded' | POS_INT;
 
-    DESCRIPTOR_RANGE_OFFSET : 'DESCRIPTOR_RANGE_OFFSET_APPEND' | POS_INT
+    DESCRIPTOR_RANGE_OFFSET = 'DESCRIPTOR_RANGE_OFFSET_APPEND' | POS_INT;
 
     StaticSampler = 'StaticSampler' '(' sReg
       [ : ( 'filter' '=' FILTER ) ]
@@ -260,15 +260,15 @@ Additionally, all keywords and enums are case-insensitive.
       [ : ( 'visibility' '=' SHADER_VISIBILITY ) ]
     ')';
 
-    bReg : 'b' DIGITS
+    bReg = 'b' DIGITS;
 
-    tReg : 't' DIGITS
+    tReg = 't' DIGITS;
 
-    uReg : 'u' DIGITS
+    uReg = 'u' DIGITS;
 
-    sReg : 's' DIGITS
+    sReg = 's' DIGITS;
 
-    FILTER : 'FILTER_MIN_MAG_MIP_POINT' |
+    FILTER = 'FILTER_MIN_MAG_MIP_POINT' |
              'FILTER_MIN_MAG_POINT_MIP_LINEAR' |
              'FILTER_MIN_POINT_MAG_LINEAR_MIP_POINT' |
              'FILTER_MIN_POINT_MAG_MIP_LINEAR' |
@@ -303,20 +303,20 @@ Additionally, all keywords and enums are case-insensitive.
              'FILTER_MAXIMUM_MIN_LINEAR_MAG_POINT_MIP_LINEAR' |
              'FILTER_MAXIMUM_MIN_MAG_LINEAR_MIP_POINT' |
              'FILTER_MAXIMUM_MIN_MAG_MIP_LINEAR' |
-             'FILTER_MAXIMUM_ANISOTROPIC'
+             'FILTER_MAXIMUM_ANISOTROPIC';
 
-    TEXTURE_ADDRESS : 'TEXTURE_ADDRESS_WRAP' |
+    TEXTURE_ADDRESS = 'TEXTURE_ADDRESS_WRAP' |
                       'TEXTURE_ADDRESS_MIRROR' | 'TEXTURE_ADDRESS_CLAMP' |
-                      'TEXTURE_ADDRESS_BORDER' | 'TEXTURE_ADDRESS_MIRROR_ONCE'
+                      'TEXTURE_ADDRESS_BORDER' | 'TEXTURE_ADDRESS_MIRROR_ONCE';
 
-    COMPARISON_FUNC : 'COMPARISON_NEVER' | 'COMPARISON_LESS' |
+    COMPARISON_FUNC = 'COMPARISON_NEVER' | 'COMPARISON_LESS' |
                       'COMPARISON_EQUAL' | 'COMPARISON_LESS_EQUAL' |
                       'COMPARISON_GREATER' | 'COMPARISON_NOT_EQUAL' |
-                      'COMPARISON_GREATER_EQUAL' | 'COMPARISON_ALWAYS'
+                      'COMPARISON_GREATER_EQUAL' | 'COMPARISON_ALWAYS';
 
-    STATIC_BORDER_COLOR : 'STATIC_BORDER_COLOR_TRANSPARENT_BLACK' |
+    STATIC_BORDER_COLOR = 'STATIC_BORDER_COLOR_TRANSPARENT_BLACK' |
                           'STATIC_BORDER_COLOR_OPAQUE_BLACK' |
-                          'STATIC_BORDER_COLOR_OPAQUE_WHITE'
+                          'STATIC_BORDER_COLOR_OPAQUE_WHITE';
 ```
 
 ### Root Signature Versioning 


### PR DESCRIPTION
Update the formatting of the root signature grammar to use EBNF in a consistent manner:

- The first commit just goes through to use `=` instead of `:` and denote statements with ';' to comply with EBNF
- The second commit comes from a suggestion [here](https://github.com/llvm/wg-hlsl/pull/195#discussion_r2012481340) to just use the `|` notation to specify the parameters in any order but not explicitly denote that they can only occur once

Clean up pr to resolve https://github.com/llvm/wg-hlsl/issues/192