### PR TITLE
[0031] Proposal for shader semantics

### DIFF
--- a/proposals/0031-semantics.md
+++ b/proposals/0031-semantics.md
@@ -1,6 +1,6 @@
 # HLSL shader semantics
 
-* Proposal: [0031](http://0031-semantics.md)
+* Proposal: [0031](0031-semantics.md)
 * Author(s): [Nathan Gauër](https://github.com/Keenuts)
 * Status: **Design In Progress**
 


### PR DESCRIPTION
This is another proposal on how to implement semantic input in Clang, given DXIL & SPIR-V have drasticly different handlings, but some parts could be shared.

The POC for this implementation is in https://github.com/llvm/llvm-project/pull/149363

Another proposal exists: #112 which also suggest a sema change.