### PR TITLE
Agenda and meeting minutes for 2025-07-17

### DIFF
--- a/meetings/2025-07-17.md
+++ b/meetings/2025-07-17.md
@@ -1,0 +1,11 @@
+# 2025-07-17 - HLSL Working Group Minutes
+
+> Propose a discussion topic by making an edit suggestion on the GitHub PR.
+
+* Discussion topics
+  * Shader semantics implementation: https://github.com/llvm/wg-hlsl/pull/296
+  * <placeholder topic>
+  * <placeholder topic>
+  * <placeholder topic>
+  * <placeholder topic>
+  * <placeholder topic>


### PR DESCRIPTION
Add the agenda and meeting minutes for the 2025-07-17 LLVM HLSL Working Group meeting.