### PR TITLE
[0029] Proposal: Add Root Signature related driver options

### DIFF
--- a/proposals/0029-root-signature-driver-options.md
+++ b/proposals/0029-root-signature-driver-options.md
@@ -2,7 +2,7 @@
 
 # Root Signature Driver Options
 
-* Proposal: [NNNN](NNNN-root-signture-driver-options.md)
+* Proposal: [0029](0029-root-signture-driver-options.md)
 * Author(s): [Finn Plummer](https//github.com/inbelic)
 * Status: **Accepted**
 * Impacted Project(s): Clang


### PR DESCRIPTION
DXC provided a number of command line options for working with root signatures. Namely: `Frs`, `Qstrip_rootsignature`, `setrootsignature`, `extractrootsignature`, `verifyrootsignature`, `force-rootsig-ver` and `rootsig-define`.

This pr proposes how the functionality of these options will be implemented into clang and documents the expected behaviour that they should provide.