### PR TITLE
Agenda and meeting minutes for 2025-07-24

### DIFF
--- a/meetings/2025-07-24.md
+++ b/meetings/2025-07-24.md
@@ -1,4 +1,6 @@
-# 2025-07-24 - HLSL Working Group Minutes
+---
+title: 2025-07-24 - HLSL Working Group Minutes
+---
 
 > Propose a discussion topic by making an edit suggestion on the GitHub PR.
 


### PR DESCRIPTION
This PR adds the meeting agenda and minutes for the 2025-07-24 LLVM HLSL Working Group meeting. To add an item to the agenda before the meeting please suggest an edit in the GitHub PR with your topic.