### PR TITLE
Agenda and meeting minutes for 2025-07-31

### DIFF
--- a/meetings/2025-07-31.md
+++ b/meetings/2025-07-31.md
@@ -1,0 +1,10 @@
+# 2025-07-31 - HLSL Working Group Minutes
+
+> Propose a discussion topic by making an edit suggestion on the GitHub PR.
+
+* Discussion topics
+  * Supporting -O0 in Clang
+  * <placeholder topic>
+  * <placeholder topic>
+  * <placeholder topic>
+  * <placeholder topic>


### PR DESCRIPTION
This PR adds the meeting agenda and minutes for the 2025-07-31 LLVM HLSL Working Group meeting.

To add an item to the agenda suggest an edit replacing a placeholder bullet.