### PR TITLE
Update site publishing to fix title and edit page link

### DIFF
--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -33,10 +33,10 @@ ignoreLogs = ['warning-goldmark-raw-html']
     source = '../meetings'
     target = 'content/meetings'
   
-  # Mount top-level README so the home page layout can read it
+  # Use README.md as the home page
   [[module.mounts]]
     source = '../README.md'
-    target = 'assets/readme.md'
+    target = 'content/_index.md'
 
   [[module.mounts]]
     source = '../proposals'

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -1,8 +1,0 @@
-{{ define "main" }}
-	{{ $readme := resources.Get "readme.md" }}
-	{{ if $readme }}
-		{{ $readme.Content | markdownify }}
-	{{ else }}
-		<p>README not found.</p>
-	{{ end }}
-{{ end }}


### PR DESCRIPTION
This updates the hugo configuration so that the "Edit on github" links work.

`README.md` is now directly mounted as `_index.md`, with the most noticeable difference being that the title on the home page is now "HLSL Working Group" rather than "HLSL Working Group - HLSL Working Group".

Also, a small tweak to hugo.toml so that the `ignoreLogs` value is top-level.