### PR TITLE
[0032] A proposal for bringing Matrix types to upstream

### DIFF
--- a/proposals/0032-hlsl-matrix.md
+++ b/proposals/0032-hlsl-matrix.md
@@ -4,7 +4,7 @@ params:
   authors:
   + farzonl: Farzon Lotfi
   + pow2clk: Greg Roth
-  status: Design In Progress
+  status: Accepted
 ---
 
 # HLSL Matrices


### PR DESCRIPTION
This proposal revives https://github.com/llvm/wg-hlsl/pull/63/
It tries to address areas not covered in the last attempt like how we will legalize the
intrinsics Clang matrix ext types use and further how we will handle the type printer concerns.