### PR TITLE
[Root Signatures] Updating docs with Version 1.2 additions

### DIFF
--- a/proposals/0002-root-signature-in-clang.md
+++ b/proposals/0002-root-signature-in-clang.md
@@ -615,6 +615,7 @@ The additional semantic rules not already covered by the grammar are listed here
       - `STATIC_BORDER_COLOR_TRANSPARENT_BLACK`
       - `STATIC_BORDER_COLOR_OPAQUE_BLACK_UINT`
       - `STATIC_BORDER_COLOR_OPAQUE_WHITE_UINT`
+  - If `BorderColor` is any of `*_UINT` values, then flag `SAMPLER_FLAG_UINT_BORDER_COLOR` must be set.
 
 - Register Value
   The value `0xFFFFFFFF` is invalid.


### PR DESCRIPTION
This PR is adding to the spec the necessary changes that need to be added into clang to support version 1.2 of root signatures.