### PR TITLE
Add agenda and minutes for 2025-09-18 meeting

### DIFF
--- a/meetings/2025-09-18.md
+++ b/meetings/2025-09-18.md
@@ -5,8 +5,8 @@ title: 2025-09-11 - HLSL Working Group Minutes
 > Propose a discussion topic by making an edit suggestion on the GitHub PR.
 
 * Discussion topics
-  * <placeholder topic>
-  * <placeholder topic>
+  * Discuss matrix types in interface variable. Cbuffer and semantics.
+  * Discuss about semantics
   * <placeholder topic>
   * <placeholder topic>
   * <placeholder topic>


### PR DESCRIPTION
This PR adds the meeting minutes and agenda for the 2025-09-18 WG-HLSL meeting.