### PR TITLE
[0036] Add HLSL Matrix expression

### DIFF
--- a/proposals/0036-hlsl-matrix-element-expr.md
+++ b/proposals/0036-hlsl-matrix-element-expr.md
@@ -1,9 +1,9 @@
 ---
-title: NNNN - HLSL Matrix Element Expression
+title: 0036 - HLSL Matrix Element Expression
 params:
   authors:
     farzonl: Farzon Lotfi
-status: Design In Progress
+status: Accepted
 ---
 
 ## Introduction
@@ -33,7 +33,7 @@ explicit per-component list and per-component source locations, the final
 design:
 
 - Reuses the existing `ExtVectorElementExpr` machinery via a shared base class.
-  - Per [Aaron Ballman Feedback](https://discourse.llvm.org/t/rfc-extend-extvectorelementexpr-for-hlsl-matrix-accessors/88802/4)
+  - Per [Aaron Ballman's Feedback](https://discourse.llvm.org/t/rfc-extend-extvectorelementexpr-for-hlsl-matrix-accessors/88802/4)
   - ExtVectorElementExpr is migrated to use this base.
   - MatrixElementExpr is introduced as a sibling.
 - Keeps the AST node compact, storing only the base expression, the accessor


### PR DESCRIPTION
fixes #354

## Purpose
* Add a dedicated matrix swizzle expression type to Clang’s AST that can represent HLSL matrix component access/sizzle constructs. 
* Ensure the new expression type preserves exact token spelling and correct per-component source location information. 
* Provide a working plan for how this expression type will be integrated into parsing, AST representation, and later compilation stages.

## Goals

* Support HLSL matrix swizzle accessors of the form Base._mij_mkl_… where each suffix identifies one or more matrix elements (row, column).
* Integrate cleanly into Clang with minimal HLSL specific changes needed for Sema (though obviously some matrix-specific logic is required hopefully this can be useful for the existing clang matrix type so we don’t pollute `ExtVectorElementExpr` HLSL LangOpts).

## Non-Goals

* Change the semantics of vector swizzles for ExtVectorElementExpr.
* Support arbitrary new syntax beyond HLSL matrix-swizzle style (i.e., no attempt to introduce fully generalized arbitrary multi-dimensional swizzle syntax).
* Modify existing vector swizzle syntax or semantics.