### PR TITLE
Add agenda and meeting minutes for 2025-11-13 meeting

### DIFF
--- a/meetings/2025-11-13.md
+++ b/meetings/2025-11-13.md
@@ -4,8 +4,13 @@ title: 2025-11-13 - HLSL Working Group Minutes
 
 * Discussion topics
   * [Maximal reconvergence tests](https://github.com/llvm/offload-test-suite/pull/473)
-    * Carried forward from 11/6 since relevant parties were not on the call
+    * One test is sensitive to wave size, the other is likely a clang bug
+      * Chris: We should fix the Clang issues by using the LLVM convergence token intrinsics in both DXIL and SPIRV code generation
+      * Steven: We should coordinate as we work though issues so we don't end up looking at the same problems 
+    * Action Item: likely to remove subgroup_uniform_control_flow and add more convergence tests in the future.
   * CBuffer explicit padding PR is up: https://github.com/llvm/llvm-project/pull/167404
-  * <placeholder topic>
-  * <placeholder topic>
-  * <placeholder topic>
+    * PR is up. Reviews are appreciated.
+  * Push constants
+    * Nathan is adding an address space for the SPIRV handling of push constants
+    * This seems fine and won't interfere with DX at all
+  * Meeting concluded after 17 minutes


### PR DESCRIPTION
This adds the agenda and meeting minutes for the 2025-11-13 HLSL working group meeting.