### PR TITLE
Add meeting minutes and agenda for 2025-12-04

### DIFF
--- a/meetings/2025-12-04.md
+++ b/meetings/2025-12-04.md
@@ -3,7 +3,7 @@ title: 2025-12-04 - HLSL Working Group Minutes
 ---
 
 * Discussion topics
-  * <placeholder topic>
+  * Discuss the state of MatrixSingleSubscript expressions and gather ideas on how to support vector swizzle operartions.
   * <placeholder topic>
   * <placeholder topic>
   * <placeholder topic>


### PR DESCRIPTION
This adds the agenda and meeting minutes for the 2025-12-04 HLSL working group meeting.