### PR TITLE
Add minutes for HLSL Working Group meeting on 2026-02-26

### DIFF
--- a/meetings/2026-02-26.md
+++ b/meetings/2026-02-26.md
@@ -1,0 +1,22 @@
+---
+title: 2026-02-26 - HLSL Working Group Minutes
+---
+
+
+* Discussion topics
+
+- Global Registry Cleanup
+Steven and Farzon discussed crashes caused by dangling types in the global registry when cleanup does not occur. A `phi` type persisted after optimization and later caused failures when reused. 
+Maintaining secondary type information is difficult and similar issues were previously observed by Intel. Types cannot simply be retained because illegal types must be removed for valid SPIR-V.
+
+- Depth Texture Tests
+Steven opened a PR adding Vulkan depth textures to the offload test suite to support sample/gather compare tests. DirectX behavior is unclear.
+
+- Texture Design PR
+Steven split the texture design changes. Nathan and Lucy will review the frontend PR first, with Helena providing final review.
+
+- Interlock Intrinsics
+Farzon reported DirectX backend work nearing completion and requested input on the desired SPIR-V representation.
+
+- SPIR-V Pointer Cast Issue
+Alexander reported backend crashes related to legalized pointer casts. He will test Farzon’s recent change as a possible fix.


### PR DESCRIPTION
Documented the minutes of the HLSL Working Group meeting held on February 26, 2026, covering various discussion topics including global registry cleanup, depth texture tests, texture design, interlock intrinsics, and SPIR-V pointer cast issues.