### PR TITLE
Update HLSL Intrinsic TableGen proposal with feedback, and set status to Approved

### DIFF
--- a/proposals/0043-hlsl-intrinsic-tablegen.md
+++ b/proposals/0043-hlsl-intrinsic-tablegen.md
@@ -1,9 +1,9 @@
 ---
-title: "[NNNN] - HLSL Intrinsic TableGen"
+title: "[0043] - HLSL Intrinsic TableGen"
 params:
   authors:
     - icohedron: Deric Cheung
-  status: Under Consideration
+  status: Approved
 ---
 
 ## Introduction


### PR DESCRIPTION
This PR updates the HLSL intrinsic TableGen proposal [0043] with some feedback from today's design meeting. 

- Made the type of the `Body` field `code` instead of `string`. There
is no difference aside from `code` being more clear that `Body` is
intended for code and not some arbitrary string. 
(See https://discourse.llvm.org/t/tablegen-code-type-to-be-eliminated/56996/8)

- Rewrote descriptions of the `Body` field to make it more clear that
it is intended for single-line implementations of inline functions.
Multi-line implementations should instead live in a helper function
called by `DetailFunc`.

- Added a section with an example of the `Doc` field being used to emit
a Doxygen comment with the first overload.

There apparently is not a `boolean` type for TableGen, only `bit` types with accept 0 or 1. 
So `VaryingScalar` remains 0 or 1.