### PR TITLE
Rename proposal doc so that it is numbered

### DIFF
--- a/proposals/0048-local-resources-behavior.md
+++ b/proposals/0048-local-resources-behavior.md
@@ -1,7 +1,7 @@
 ---
-title: "[NNNN] - Local Resources Behavior"
+title: "[0048] - Local Resources Behavior"
 params:
-  status: Under Consideration
+  status: Accepted
   authors:
     - bob80905: Joshua Batista
 ---


### PR DESCRIPTION
The PR https://github.com/llvm/wg-hlsl/pull/414
failed to specify the proposal number.
This PR just sets the proposal number, and changes the status to accepted.